### PR TITLE
Support Gardener credentials data keys

### DIFF
--- a/kubernetes/secret.yaml
+++ b/kubernetes/secret.yaml
@@ -9,6 +9,11 @@ data:
   azureClientSecret: value3
   azureSubscriptionId: value4
   azureTenantId: value5
+### Alternative data keys are:
+# clientID: value2
+# clientSecret: value3
+# subscriptionID: value4
+# tenantID: value5
 kind: Secret
 metadata:
   name: test-secret

--- a/pkg/azure/apis/azure_provider_spec.go
+++ b/pkg/azure/apis/azure_provider_spec.go
@@ -7,6 +7,26 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 const (
+	// AzureClientID is a constant for a key name that is part of the Azure cloud credentials.
+	AzureClientID string = "azureClientId"
+	// AzureClientSecret is a constant for a key name that is part of the Azure cloud credentials.
+	AzureClientSecret string = "azureClientSecret"
+	// AzureSubscriptionID is a constant for a key name that is part of the Azure cloud credentials.
+	AzureSubscriptionID string = "azureSubscriptionId"
+	// AzureTenantID is a constant for a key name that is part of the Azure cloud credentials.
+	AzureTenantID string = "azureTenantId"
+
+	// AzureAlternativeClientID is a constant for a key name of a secret containing the Azure credentials (client id).
+	AzureAlternativeClientID = "clientID"
+	// AzureAlternativeClientSecret is a constant for a key name of a secret containing the Azure credentials (client
+	// secret).
+	AzureAlternativeClientSecret = "clientSecret"
+	// AzureAlternativeSubscriptionID is a constant for a key name of a secret containing the Azure credentials
+	// (subscription id).
+	AzureAlternativeSubscriptionID = "subscriptionID"
+	// AzureAlternativeTenantID is a constant for a key name of a secret containing the Azure credentials (tenant id).
+	AzureAlternativeTenantID = "tenantID"
+
 	// MachineSetKindAvailabilitySet is the machine set kind for AvailabilitySet
 	MachineSetKindAvailabilitySet string = "availabilityset"
 	// MachineSetKindVMO is the machine set kind for VirtualMachineScaleSet Orchestration Mode VM (VMO)

--- a/pkg/azure/apis/validation/validation.go
+++ b/pkg/azure/apis/validation/validation.go
@@ -183,20 +183,20 @@ func validateSpecTags(tags map[string]string) []error {
 func validateSecrets(secret *corev1.Secret) []error {
 	var allErrs []error
 
-	if "" == string(secret.Data["azureClientId"]) {
-		allErrs = append(allErrs, fmt.Errorf("Secret azureClientId is required field"))
+	if "" == string(secret.Data[api.AzureClientID]) && "" == string(secret.Data[api.AzureAlternativeClientID]) {
+		allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", api.AzureClientID, api.AzureAlternativeClientID))
 	}
-	if "" == string(secret.Data["azureClientSecret"]) {
-		allErrs = append(allErrs, fmt.Errorf("Secret azureClientSecret is required field"))
+	if "" == string(secret.Data[api.AzureClientSecret]) && "" == string(secret.Data[api.AzureAlternativeClientSecret]) {
+		allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", api.AzureClientSecret, api.AzureAlternativeClientSecret))
 	}
-	if "" == string(secret.Data["azureTenantId"]) {
-		allErrs = append(allErrs, fmt.Errorf("Secret azureTenantId is required field"))
+	if "" == string(secret.Data[api.AzureTenantID]) && "" == string(secret.Data[api.AzureAlternativeTenantID]) {
+		allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", api.AzureTenantID, api.AzureAlternativeTenantID))
 	}
-	if "" == string(secret.Data["azureSubscriptionId"]) {
-		allErrs = append(allErrs, fmt.Errorf("Secret azureSubscriptionId is required field"))
+	if "" == string(secret.Data[api.AzureSubscriptionID]) && "" == string(secret.Data[api.AzureAlternativeSubscriptionID]) {
+		allErrs = append(allErrs, fmt.Errorf("secret %s or %s is required field", api.AzureSubscriptionID, api.AzureAlternativeSubscriptionID))
 	}
 	if "" == string(secret.Data["userData"]) {
-		allErrs = append(allErrs, fmt.Errorf("Secret UserData is required field"))
+		allErrs = append(allErrs, fmt.Errorf("secret UserData is required field"))
 	}
 	return allErrs
 }

--- a/pkg/azure/core_test.go
+++ b/pkg/azure/core_test.go
@@ -25,15 +25,15 @@ var _ = Describe("MachineController", func() {
 
 	azureProviderSecret := map[string][]byte{
 		"userData":            []byte("dummy-data"),
-		"azureClientID":       []byte("dummy-client-id"),
+		"azureClientId":       []byte("dummy-client-id"),
 		"azureClientSecret":   []byte("dummy-client-secret"),
 		"azureSubscriptionId": []byte("dummy-subcription-id"),
 		"azureTenantId":       []byte("dummy-tenant-id"),
 	}
 
-	azureProviderSecretWithoutazureClientID := map[string][]byte{
+	azureProviderSecretWithoutazureClientId := map[string][]byte{
 		"userData":            []byte("dummy-data"),
-		"azureClientID":       []byte(""),
+		"azureClientId":       []byte(""),
 		"azureClientSecret":   []byte("dummy-client-secret"),
 		"azureSubscriptionId": []byte("dummy-subcription-id"),
 		"azureTenantId":       []byte("dummy-tenant-id"),
@@ -41,7 +41,7 @@ var _ = Describe("MachineController", func() {
 
 	azureProviderSecretWithoutazureClientSecret := map[string][]byte{
 		"userData":            []byte("dummy-data"),
-		"azureClientID":       []byte("dummy-client-id"),
+		"azureClientId":       []byte("dummy-client-id"),
 		"azureClientSecret":   []byte(""),
 		"azureSubscriptionId": []byte("dummy-subcription-id"),
 		"azureTenantId":       []byte("dummy-tenant-id"),
@@ -49,7 +49,7 @@ var _ = Describe("MachineController", func() {
 
 	azureProviderSecretWithoutazureTenantID := map[string][]byte{
 		"userData":            []byte("dummy-data"),
-		"azureClientID":       []byte("dummy-client-id"),
+		"azureClientId":       []byte("dummy-client-id"),
 		"azureClientSecret":   []byte("dummy-client-secret"),
 		"azureSubscriptionId": []byte("dummy-subcription-id"),
 		"azureTenantId":       []byte(""),
@@ -57,7 +57,7 @@ var _ = Describe("MachineController", func() {
 
 	azureProviderSecretWithoutazureSubscriptionID := map[string][]byte{
 		"userData":            []byte("dummy-data"),
-		"azureClientID":       []byte("dummy-client-id"),
+		"azureClientId":       []byte("dummy-client-id"),
 		"azureClientSecret":   []byte("dummy-client-secret"),
 		"azureSubscriptionId": []byte(""),
 		"azureTenantId":       []byte("dummy-tenant-id"),
@@ -65,7 +65,7 @@ var _ = Describe("MachineController", func() {
 
 	azureProviderSecretWithoutUserData := map[string][]byte{
 		"userData":            []byte(""),
-		"azureClientID":       []byte("dummy-client-id"),
+		"azureClientId":       []byte("dummy-client-id"),
 		"azureClientSecret":   []byte("dummy-client-secret"),
 		"azureSubscriptionId": []byte("dummy-subcription-id"),
 		"azureTenantId":       []byte("dummy-tenant-id"),
@@ -139,7 +139,7 @@ var _ = Describe("MachineController", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret UserData is required field]]]",
+					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret UserData is required field]]]",
 				},
 			}),
 			Entry("#3 CreateMachine fails: Absence of Location in providerspec", &data{
@@ -377,17 +377,17 @@ var _ = Describe("MachineController", func() {
 					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [providerSpec.kubernetes.io-role-: Required value: Tag required of the form kubernetes.io-role-****]]]",
 				},
 			}),
-			Entry("#22 CreateMachine fails: Absence of azureClientID in secret", &data{
+			Entry("#22 CreateMachine fails: Absence of azureClientId in secret", &data{
 				action: action{
 					machineRequest: &driver.CreateMachineRequest{
 						Machine:      newMachine("dummy-machine"),
 						MachineClass: newAzureMachineClass(fake.AzureProviderSpec),
-						Secret:       newSecret(azureProviderSecretWithoutazureClientID),
+						Secret:       newSecret(azureProviderSecretWithoutazureClientId),
 					},
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret azureClientID is required field]]]",
+					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret azureClientId or clientID is required field]]]",
 				},
 			}),
 			Entry("#23 CreateMachine fails: Absence of azureClientSecret in secret", &data{
@@ -400,7 +400,7 @@ var _ = Describe("MachineController", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret azureClientSecret is required field]]]",
+					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret azureClientSecret or clientSecret is required field]]]",
 				},
 			}),
 			Entry("#24 CreateMachine fails: Absence of azureTenantId in secret", &data{
@@ -413,7 +413,7 @@ var _ = Describe("MachineController", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret azureTenantId is required field]]]",
+					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret azureTenantId or tenantID is required field]]]",
 				},
 			}),
 			Entry("#25 CreateMachine fails: Absence of azureSubscriptionId in secret", &data{
@@ -426,7 +426,7 @@ var _ = Describe("MachineController", func() {
 				},
 				expect: expect{
 					errToHaveOccurred: true,
-					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [Secret azureSubscriptionId is required field]]]",
+					errMessage:        "machine codes error: code = [Unknown] message = [machine codes error: code = [Internal] message = [Error while validating ProviderSpec [secret azureSubscriptionId or subscriptionID is required field]]]",
 				},
 			}),
 		)


### PR DESCRIPTION
/area open-source usability
/kind enhancement
/priority normal
/platform azure

**What this PR does / why we need it**:
All the secret keys used by Gardener are now also allowed as alternatives for this machine-controller-manager plugin. This helps to not make mappings for the data keys.

**Special notes for your reviewer**:
ℹ️ Similar improvement for in-tree driver: https://github.com/gardener/machine-controller-manager/pull/578/commits/0e41070979b21dae4e27fe6504bdc99f651ec3b7 (https://github.com/gardener/machine-controller-manager/pull/578)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```feature operator
The machine class secret does now also accept the data keys `clientID`, `clientSecret`, `subscriptionID` and `tenantID` as alternatives for today's keys.
```