### PR TITLE
add a check on provider of the machineclass in the driver methods

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -10,6 +10,7 @@ kind: MachineClass
 metadata:
   name: <machineclass-name>
   namespace: <machineclass namespace>
+provider: azure
 providerSpec:
   location: westeurope
   properties:

--- a/pkg/azure/core.go
+++ b/pkg/azure/core.go
@@ -23,6 +23,14 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	// AzureMachineClassKind is the constant representing the AzureMachineClass
+	AzureMachineClassKind = "AzureMachineClass"
+
+	// ProviderAzure is the constant representing the Cloud Provider Azure
+	ProviderAzure = "azure"
+)
+
 // NOTE
 //
 // The basic working of the controller will work with just implementing the CreateMachine() & DeleteMachine() methods.
@@ -57,9 +65,6 @@ type MachinePlugin struct {
 	Secret            *corev1.Secret
 }
 
-// AzureMachineClassKind for Azure Machine Class
-const AzureMachineClassKind = "AzureMachineClass"
-
 // NewAzureDriver returns an empty AzureDriver object
 func NewAzureDriver(spi spi.SessionProviderInterface) *MachinePlugin {
 	return &MachinePlugin{
@@ -76,6 +81,11 @@ func (d *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMac
 	// Log messages to track request
 	klog.V(2).Infof("Machine creation request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine creation request has been processed for %q", req.Machine.Name)
+
+	// Check if incoming CR is a CR we support
+	if req.MachineClass.Provider != ProviderAzure {
+		return nil, fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAzure)
+	}
 
 	d.Secret = req.Secret
 	virtualMachine, err := d.createVMNicDisk(req)
@@ -104,6 +114,11 @@ func (d *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMac
 	// Log messages to track delete request
 	klog.V(2).Infof("Machine deletion request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
+
+	// Check if incoming CR is a CR we support
+	if req.MachineClass.Provider != ProviderAzure {
+		return nil, fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAzure)
+	}
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	if err != nil {
@@ -166,6 +181,11 @@ func (d *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMac
 	klog.V(2).Infof("Get request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine get request has been processed successfully for %q", req.Machine.Name)
 
+	// Check if incoming CR is a CR we support
+	if req.MachineClass.Provider != ProviderAzure {
+		return nil, fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAzure)
+	}
+
 	var machineStatusResponse = &driver.GetMachineStatusResponse{}
 
 	listMachineRequest := &driver.ListMachinesRequest{MachineClass: req.MachineClass, Secret: req.Secret}
@@ -202,6 +222,11 @@ func (d *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachin
 	// Log messages to track start and end of request
 	klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
 	defer klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
+
+	// Check if incoming CR is a CR we support
+	if req.MachineClass.Provider != ProviderAzure {
+		return nil, fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderAzure)
+	}
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
 	d.AzureProviderSpec = providerSpec

--- a/pkg/azure/core_test.go
+++ b/pkg/azure/core_test.go
@@ -183,6 +183,24 @@ var _ = Describe("MachineController", func() {
 				false,
 				"",
 			),
+			Entry("#1 Create a simple machine with wrong provider value in Machine Class",
+				&mock.AzureProviderSpec,
+				&driver.CreateMachineRequest{
+					Machine:      newMachine("dummy-machine"),
+					MachineClass: newAzureMachineClassWithProvider(mock.AzureProviderSpec, "aws"),
+					Secret:       newSecret(azureProviderSecret),
+				},
+				&driver.CreateMachineResponse{
+					ProviderID: "azure:///westeurope/dummy-machine",
+					NodeName:   "dummy-machine",
+				},
+				nil,
+				nil,
+				nil,
+				nil,
+				true,
+				fmt.Errorf("Requested for Provider 'aws', we only support '%s'", ProviderAzure).Error(),
+			),
 			Entry("#2 Create machine without client id in secret",
 				&mock.AzureProviderSpec,
 				&driver.CreateMachineRequest{
@@ -741,7 +759,24 @@ var _ = Describe("MachineController", func() {
 				false,
 				nil,
 			),
-
+			Entry("#2 Delete a machine",
+				&mock.AzureProviderSpec,
+				&driver.DeleteMachineRequest{
+					Machine:      newMachine("dummy-machine"),
+					MachineClass: newAzureMachineClassWithProvider(mock.AzureProviderSpec, "aws"),
+					Secret:       newSecret(azureProviderSecret),
+				},
+				&driver.DeleteMachineResponse{
+					LastKnownState: "",
+				},
+				nil,
+				false,
+				false,
+				false,
+				nil,
+				true,
+				fmt.Errorf("Requested for Provider '%s', we only support '%s'", "aws", ProviderAzure).Error(),
+			),
 			Entry("#2 Delete a machine while a NIC is still attached",
 				&mock.AzureProviderSpec,
 				&driver.DeleteMachineRequest{
@@ -970,6 +1005,22 @@ var _ = Describe("MachineController", func() {
 				false,
 				"",
 			),
+			Entry("#1 List machines with wrong MachineClass Provider",
+				&mock.AzureProviderSpec,
+				&driver.ListMachinesRequest{
+					MachineClass: newAzureMachineClassWithProvider(mock.AzureProviderSpec, "aws"),
+					Secret:       newSecret(azureProviderSecret),
+				},
+				&driver.ListMachinesResponse{
+					MachineList: map[string]string{
+						"azure:///westeurope/dummy-machine": "dummy-machine",
+					},
+				},
+				false,
+				nil,
+				true,
+				fmt.Errorf("Requested for Provider '%s', we only support '%s'", "aws", ProviderAzure).Error(),
+			),
 			Entry("#2 List machines with VM List error scenario",
 				&mock.AzureProviderSpec,
 				&driver.ListMachinesRequest{
@@ -1084,6 +1135,30 @@ var _ = Describe("MachineController", func() {
 				nil,
 				false,
 				"",
+			),
+			Entry("#1 GetMachineStatus of machine with wrong MachineClass reference",
+				&mock.AzureProviderSpec,
+				&driver.GetMachineStatusRequest{
+					Machine:      newMachine("dummy-machine"),
+					MachineClass: newAzureMachineClassWithProvider(mock.AzureProviderSpec, "aws"),
+					Secret:       newSecret(azureProviderSecret),
+				},
+				&driver.GetMachineStatusResponse{
+					NodeName:   "dummy-machine",
+					ProviderID: "azure:///westeurope/dummy-machine",
+				},
+				compute.VirtualMachineListResult{
+					Value: &[]compute.VirtualMachine{
+						{
+							Name:     getStringPointer("dummy-machine"),
+							Location: getStringPointer("westeurope"),
+						},
+					},
+					NextLink: getStringPointer(""),
+				},
+				nil,
+				true,
+				fmt.Errorf("Requested for Provider '%s', we only support '%s'", "aws", ProviderAzure).Error(),
 			),
 			Entry("#2 GetMachineStatus of non existing machine",
 				&mock.AzureProviderSpec,
@@ -1533,6 +1608,19 @@ func newMachine(name string) *v1alpha1.Machine {
 	}
 }
 
+func newAzureMachineClassWithProvider(azureProviderSpec apis.AzureProviderSpec, provider string) *v1alpha1.MachineClass {
+	byteData, _ := json.Marshal(azureProviderSpec)
+	return &v1alpha1.MachineClass{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "default",
+		},
+		ProviderSpec: runtime.RawExtension{
+			Raw: byteData,
+		},
+		Provider: provider,
+	}
+}
+
 func newAzureMachineClass(azureProviderSpec apis.AzureProviderSpec) *v1alpha1.MachineClass {
 	byteData, _ := json.Marshal(azureProviderSpec)
 	return &v1alpha1.MachineClass{
@@ -1542,6 +1630,7 @@ func newAzureMachineClass(azureProviderSpec apis.AzureProviderSpec) *v1alpha1.Ma
 		ProviderSpec: runtime.RawExtension{
 			Raw: byteData,
 		},
+		Provider: ProviderAzure,
 	}
 }
 
@@ -1555,6 +1644,7 @@ func newAzureMachineClassWithError() *v1alpha1.MachineClass {
 		ProviderSpec: runtime.RawExtension{
 			Raw: byteData,
 		},
+		Provider: ProviderAzure,
 	}
 }
 
@@ -1600,6 +1690,7 @@ func getMigratedMachineClass(providerSpecificMachineClass interface{}) *v1alpha1
 		ProviderSpec: runtime.RawExtension{
 			Raw: providerSpecMarshal,
 		},
+		Provider:  ProviderAzure,
 		SecretRef: providerSpecificMachineClass.(*v1alpha1.AzureMachineClass).Spec.SecretRef,
 	}
 

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -606,6 +606,7 @@ func fillUpMachineClass(azureMachineClass *v1alpha1.AzureMachineClass, machineCl
 		return status.Error(codes.Internal, err.Error())
 	}
 
+	machineClass.Provider = ProviderAzure
 	machineClass.SecretRef = azureMachineClass.Spec.SecretRef
 	machineClass.CredentialsSecretRef = azureMachineClass.Spec.CredentialsSecretRef
 	machineClass.Name = azureMachineClass.Name


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a check to verify that the MachineClass being passed for MachineCreation, Deletion and other driver methods belongs to the relevant cloud provider

**Which issue(s) this PR fixes**:
Fixes [#599](https://github.com/gardener/machine-controller-manager/issues/599)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```