### PR TITLE
Fixes regressions while fetching CSI volume-IDs

### DIFF
--- a/pkg/azure/core.go
+++ b/pkg/azure/core.go
@@ -29,6 +29,9 @@ const (
 
 	// ProviderAzure is the constant representing the Cloud Provider Azure
 	ProviderAzure = "Azure"
+
+	// AzureDiskDriverName is the name of the CSI driver for Azure Disk
+	AzureDiskDriverName = "disk.csi.azure.com"
 )
 
 // NOTE
@@ -290,12 +293,13 @@ func (d *MachinePlugin) GetVolumeIDs(ctx context.Context, req *driver.GetVolumeI
 
 	for i := range specs {
 		spec := specs[i]
-		if spec.AzureDisk == nil {
-			// Not an azure volume
-			continue
+		if spec.AzureDisk != nil {
+			name := spec.AzureDisk.DiskName
+			names = append(names, name)
+		} else if spec.CSI != nil && spec.CSI.Driver == AzureDiskDriverName && spec.CSI.VolumeHandle != "" {
+			name := spec.CSI.VolumeHandle
+			names = append(names, name)
 		}
-		name := spec.AzureDisk.DiskName
-		names = append(names, name)
 	}
 
 	return &driver.GetVolumeIDsResponse{VolumeIDs: names}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR fixes regressions that were missed during migration to OOT drivers.
It caries over the changes for the azure_driver.go file on this [MCM PR 509](https://github.com/gardener/machine-controller-manager/pull/509/files#diff-36365e28193d28c39f36ac4d9172fbf8eac69553361f6179fa3184f9cad9eb0cR46-R1178)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A regression that I noticed while trying to drain kubernetes clusters using CSI volumes on Azure

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy user
Fixes regressions fetching volumeIDs to Azure CSI volumes
```