### PR TITLE
Updates deployment.go to use latest images

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: machine-controller-manager
-          image: eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.38.0
+          image: eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.39.0
           imagePullPolicy: Always
           command:
             - ./machine-controller-manager
@@ -49,7 +49,7 @@ spec:
             - --machine-safety-orphan-vms-period=30m # Optional Parameter - Default value 30mins - Time period (in time) used to poll for orphan VMs by safety controller.
             - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
             - --v=3
-          image: gcr.io/gardener-project/gardener/machine-controller-manager-provider-azure:v0.1.0
+          image: gcr.io/gardener-project/gardener/machine-controller-manager-provider-azure:v0.5.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
updates the deployment.go file. This file will now be used by Azure integration test to create the MCM deployment.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Not used 0.40.0 version of MCM as of now, sticking to 0.39.0 as I have testing with that only for now for other providers. feel free to change it to 0.40.0.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```