### PR TITLE
update pipeline definitions with test machinery image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,11 +2,8 @@ machine-controller-manager-provider-azure:
   template: 'default'
   base_definition:
     repo: ~
-    traits:
-      version:
-        preprocess:
-          'inject-commit-hash'
-        inject_effective_version: true
+  inherit:
+    publish_template: &publish_anchor
       publish:
         dockerimages:
           machine-controller-manager-provider-azure:
@@ -17,24 +14,43 @@ machine-controller-manager-provider-azure:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-azure'
-    steps:
-      check:
-        image: 'golang:1.16.6'
-      build:
-        image: 'golang:1.16.6'
-        output_dir: 'binary'
-      test:
-        image: 'golang:1.16.6'
+    steps_template: &steps_anchor
+      steps:
+        check:
+          image: 'golang:1.16.6'
+        build:
+          image: 'golang:1.16.6'
+          output_dir: 'binary'
+        test:
+          image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
+    version_template: &version_anchor
+      version:
+        inject_effective_version: true
   jobs:
     head-update:
+      <<: *steps_anchor
       traits:
+        <<: *version_anchor
         component_descriptor: ~
         draft_release: ~
+        <<: *publish_anchor
     pull-request:
+      <<: *steps_anchor
       traits:
+        <<: *version_anchor
         pull-request: ~
-    release:
+        <<: *publish_anchor
+    create-upgrade-prs:
       traits:
+        component_descriptor: ~
+        version: ~
+        cronjob:
+          interval: '5m'
+        update_component_deps: ~
+    release:
+      <<: *steps_anchor
+      traits:
+        <<: *publish_anchor
         version:
           preprocess: 'finalize'
         release:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the test machinery images in the pipeline definition

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have referred the pipeline definition from [MCM-Provider-AWS](https://github.com/gardener/machine-controller-manager-provider-aws)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```