### PR TITLE
Use ginkgo v1 for tests

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -16,6 +16,9 @@
 
 set -e
 
+# to mute ginkgo deprecation warnings
+ export ACK_GINKGO_DEPRECATIONS=2.0.0
+
 # For the test step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
 
@@ -50,7 +53,7 @@ fi
 
 # Install Ginkgo (test framework) to be able to execute the tests.
 echo "Fetching Ginkgo framework"
-GO111MODULE=off go get -u github.com/onsi/ginkgo/ginkgo
+GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 echo "Successfully fetched Ginkgo framework"
 
 ##############################################################################


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently there has been a major version jump in ginkgo, due to which tests are failing.
This PR will enable use of latest v1.16.5 of ginkgo for tests.

**Special notes for your reviewer**:
`go install` is used as it doesn't affect go.mod and `go get` doesn't support getting a particular version without affecting go.mod.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Ginkgo version 1.16.5 is used for tests until changes compatible with v2.0.0 are made.
```