### PR TITLE
Automated cherry pick of #62: Update alpine base image to 3.15.4

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -17,9 +17,9 @@ machine-controller-manager-provider-azure:
     steps_template: &steps_anchor
       steps:
         check:
-          image: 'golang:1.17.5'
+          image: 'golang:1.17.9'
         build:
-          image: 'golang:1.17.5'
+          image: 'golang:1.17.9'
           output_dir: 'binary'
         test:
           image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.15.0 as base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.15.4 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder                                  #############
-FROM golang:1.17.5 AS builder
+FROM golang:1.17.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-azure
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.15.4 as base
+FROM alpine:3.15.4 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /


### PR DESCRIPTION
Cherry pick of #62 on rel-v0.6.

#62: Update alpine base image to 3.15.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Base image updated to alpine `v3.15.4` and build image to golang `1.17.9`.
```