### PR TITLE
Abort `ListMachines` call if resource group is gone.

### DIFF
--- a/pkg/azure/core_test.go
+++ b/pkg/azure/core_test.go
@@ -1109,6 +1109,7 @@ var _ = Describe("MachineController", func() {
 					resourceGroupName = providerSpec.ResourceGroup
 				)
 
+				fakeClients.Group.EXPECT().Get(gomock.Any(), resourceGroupName).Return(resources.Group{Name: &resourceGroupName}, nil)
 				vmlrp := compute.NewVirtualMachineListResultPage(
 					vmlr,
 					func(context.Context, compute.VirtualMachineListResult) (compute.VirtualMachineListResult, error) {
@@ -2140,6 +2141,8 @@ func assertVMResourcesForListingMachine(
 	nextWithContextError bool,
 	vmListError *autorest.DetailedError,
 ) {
+	fakeClients.Group.EXPECT().Get(gomock.Any(), resourceGroupName).Return(resources.Group{Name: &resourceGroupName}, nil)
+
 	var vmlr compute.VirtualMachineListResultPage
 	if !nextWithContextError {
 		vmlr = compute.NewVirtualMachineListResultPage(

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -1133,3 +1133,18 @@ func verifyAzureTags(tags map[string]*string, clusterNameTag, nodeRoleTag string
 
 	return true
 }
+
+// inspectResourceGroup inspects if a given resource group by name is available on Azure.
+// The function will return an error which will be nil if the resource group exists.
+// In case the resource group does not exists on Azure an NotFound error will be returned.
+// If the Azure api call not succeed for other reasons an Internal error will be returned.
+func inspectResourceGroup(ctx context.Context, clients spi.AzureDriverClientsInterface, resourceGroupName string) error {
+	if _, err := clients.GetGroup().Get(ctx, resourceGroupName); err != nil {
+		if NotFound(err) {
+			return status.Error(codes.NotFound, err.Error())
+		}
+		return status.Error(codes.Internal, err.Error())
+	}
+
+	return nil
+}

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -1133,18 +1133,3 @@ func verifyAzureTags(tags map[string]*string, clusterNameTag, nodeRoleTag string
 
 	return true
 }
-
-// inspectResourceGroup inspects if a given resource group by name is available on Azure.
-// The function will return an error which will be nil if the resource group exists.
-// In case the resource group does not exists on Azure an NotFound error will be returned.
-// If the Azure api call not succeed for other reasons an Internal error will be returned.
-func inspectResourceGroup(ctx context.Context, clients spi.AzureDriverClientsInterface, resourceGroupName string) error {
-	if _, err := clients.GetGroup().Get(ctx, resourceGroupName); err != nil {
-		if NotFound(err) {
-			return status.Error(codes.NotFound, err.Error())
-		}
-		return status.Error(codes.Internal, err.Error())
-	}
-
-	return nil
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
The deletion of a machine will be blocked in case the underlying resource group is not available on Azure.
The `DeleteMachine()` function is already checking if the resource group is available and if not the deletion flow will be aborted.
During the deletion flow the `ListMachines()` function is also called by other means e.g. safety controller and the list machine call towards Azure will fail if the resource group is gone. As result mcm-provider-azure is not able to complete the machine deletion.

This PR adds the resource group availability check also to the `ListMachines()` function in addition to the `DeleteMachine()` function.

**Which issue(s) this PR fixes**:
Fixes #19

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
An issue that let the safety controller block the machine deletion if the Azure resource group is not available has been fixed.
```

/invite @himanshu-kun 