### PR TITLE
Add support for sharedGalleryImageID in azure image reference

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -34,6 +34,7 @@ providerSpec:
       imageReference:
         urn: sap:gardenlinux:greatest:184.0.0
       # communityGalleryImageID: /CommunityGalleries/<community-gallery-id>/Images/<image-name>/Versions/<image-version>
+      # sharedGalleryImageID: /SharedGalleries/<sharedGalleryName>/Images/<sharedGalleryImageName>/Versions/<sharedGalleryImageVersionName>
       osDisk:
         caching: None
         createOption: FromImage

--- a/pkg/azure/apis/azure_provider_spec.go
+++ b/pkg/azure/apis/azure_provider_spec.go
@@ -75,14 +75,16 @@ type AzureStorageProfile struct {
 }
 
 // AzureImageReference is specifies information about the image to use. You can specify information about platform images,
-// marketplace images, community images or virtual machine images. This element is required when you want to use a platform image,
-// marketplace image, community image or virtual machine image, but is not used in other creation operations.
+// marketplace images, community images, shared gallery images or virtual machine images. This element is required when you want to use a platform image,
+// marketplace image, community image, shared gallery image or virtual machine image, but is not used in other creation operations.
 type AzureImageReference struct {
 	ID string `json:"id,omitempty"`
 	// Uniform Resource Name of the OS image to be used , it has the format 'publisher:offer:sku:version'
 	URN *string `json:"urn,omitempty"`
 	// CommunityGalleryImageID is the id of the OS image to be used, hosted within an Azure Community Image Gallery.
 	CommunityGalleryImageID *string `json:"communityGalleryImageID,omitempty"`
+	// SharedGalleryImageID is the id of the OS image to be used, hosted within an Azure Shared Image Gallery.
+	SharedGalleryImageID *string `json:"sharedGalleryImageID,omitempty"`
 }
 
 // AzureOSDisk is specifies information about the operating system disk used by the virtual machine. <br><br> For more

--- a/pkg/azure/apis/validation/validation.go
+++ b/pkg/azure/apis/validation/validation.go
@@ -198,7 +198,7 @@ func ValidateImageReference(imageRef api.AzureImageReference, fldPath *field.Pat
 
 	if !isEmptyStringPtr(imageRef.URN) {
 		if !isEmptyStringPtr(imageRef.CommunityGalleryImageID) || !isEmptyString(imageRef.ID) || !isEmptyStringPtr(imageRef.SharedGalleryImageID) {
-			return append(allErrs, field.Required(fldPath.Child("urn"), "cannot specify a urn and community gallery image id, shared gallery image id or image id in parallel"))
+			return append(allErrs, field.Required(fldPath.Child("urn"), "cannot specify community gallery image id, shared gallery image id or image id when urn is specified"))
 		}
 
 		urnParts := strings.Split(*imageRef.URN, ":")
@@ -217,7 +217,7 @@ func ValidateImageReference(imageRef api.AzureImageReference, fldPath *field.Pat
 
 	if !isEmptyStringPtr(imageRef.CommunityGalleryImageID) {
 		if !isEmptyString(imageRef.ID) || !isEmptyStringPtr(imageRef.SharedGalleryImageID) {
-			return append(allErrs, field.Required(fldPath.Child("communityGalleryImageID"), "cannot specify a community image gallery id and shared image gallery id or image id in parallel"))
+			return append(allErrs, field.Required(fldPath.Child("communityGalleryImageID"), "cannot specify shared gallery image id or image id when community gallery image id is specified"))
 		}
 
 		return allErrs

--- a/pkg/azure/apis/validation/validation.go
+++ b/pkg/azure/apis/validation/validation.go
@@ -192,13 +192,13 @@ func validateSecrets(secret *corev1.Secret) []error {
 func ValidateImageReference(imageRef api.AzureImageReference, fldPath *field.Path) []error {
 	var allErrs []error
 
-	if isEmptyStringPtr(imageRef.URN) && isEmptyStringPtr(imageRef.CommunityGalleryImageID) && isEmptyString(imageRef.ID) {
-		return append(allErrs, field.Required(fldPath, "must specify either a image id, community gallery image id or an urn"))
+	if isEmptyStringPtr(imageRef.URN) && isEmptyStringPtr(imageRef.CommunityGalleryImageID) && isEmptyString(imageRef.ID) && isEmptyStringPtr(imageRef.SharedGalleryImageID) {
+		return append(allErrs, field.Required(fldPath, "must specify either a image id, community gallery image id, shared gallery image id or an urn"))
 	}
 
 	if !isEmptyStringPtr(imageRef.URN) {
-		if !isEmptyStringPtr(imageRef.CommunityGalleryImageID) || !isEmptyString(imageRef.ID) {
-			return append(allErrs, field.Required(fldPath.Child("urn"), "cannot specify a urn and community gallery image id or image id in parallel"))
+		if !isEmptyStringPtr(imageRef.CommunityGalleryImageID) || !isEmptyString(imageRef.ID) || !isEmptyStringPtr(imageRef.SharedGalleryImageID) {
+			return append(allErrs, field.Required(fldPath.Child("urn"), "cannot specify a urn and community gallery image id, shared gallery image id or image id in parallel"))
 		}
 
 		urnParts := strings.Split(*imageRef.URN, ":")
@@ -216,10 +216,17 @@ func ValidateImageReference(imageRef api.AzureImageReference, fldPath *field.Pat
 	}
 
 	if !isEmptyStringPtr(imageRef.CommunityGalleryImageID) {
-		if !isEmptyString(imageRef.ID) {
-			return append(allErrs, field.Required(fldPath.Child("communityGalleryImageID"), "invalid community gallery image id format, empty field"))
+		if !isEmptyString(imageRef.ID) || !isEmptyStringPtr(imageRef.SharedGalleryImageID) {
+			return append(allErrs, field.Required(fldPath.Child("communityGalleryImageID"), "cannot specify a community image gallery id and shared image gallery id or image id in parallel"))
 		}
 
+		return allErrs
+	}
+
+	if !isEmptyStringPtr(imageRef.SharedGalleryImageID) {
+		if !isEmptyString(imageRef.ID) {
+			return append(allErrs, field.Required(fldPath.Child("sharedGalleryImageID"), "cannot specify a shared image gallery id and image id in parallel"))
+		}
 		return allErrs
 	}
 

--- a/pkg/azure/apis/validation/validation_test.go
+++ b/pkg/azure/apis/validation/validation_test.go
@@ -39,23 +39,30 @@ var _ = Describe("#Validate", func() {
 			},
 			HaveLen(0),
 		),
+		Entry("should allow to specify shared image id",
+			api.AzureImageReference{
+				SharedGalleryImageID: pointer.StringPtr("test-shared-image-id"),
+			},
+			HaveLen(0),
+		),
 		Entry("should allow to specify image id",
 			api.AzureImageReference{
 				ID: "test-image-id",
 			},
 			HaveLen(0),
 		),
-		Entry("should forbid as no urn, no community image and no image id is specified",
+		Entry("should forbid as no urn, no community image, no shared image and no image id is specified",
 			api.AzureImageReference{},
 			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("storageProfile.imageReference"),
 			}))),
 		),
-		Entry("should forbid to specify community image id or image id when an urn is specified",
+		Entry("should forbid to specify community image id, shared image id or image id when an urn is specified",
 			api.AzureImageReference{
 				URN:                     pointer.StringPtr("abc:def:ghi:jkl"),
 				CommunityGalleryImageID: pointer.StringPtr("test-community-image-id"),
+				SharedGalleryImageID:    pointer.StringPtr("test-shared-image-id"),
 				ID:                      "test-image-id",
 			},
 			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -81,14 +88,25 @@ var _ = Describe("#Validate", func() {
 				"Field": Equal("storageProfile.imageReference.urn"),
 			}))),
 		),
-		Entry("should forbid to specify a community image id and an image id",
+		Entry("should forbid to specify a community image id and an image id or shared image id",
 			api.AzureImageReference{
 				CommunityGalleryImageID: pointer.StringPtr("test-community-image-id"),
+				SharedGalleryImageID:    pointer.StringPtr("test-shared-image-id"),
 				ID:                      "test-image-id",
 			},
 			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("storageProfile.imageReference.communityGalleryImageID"),
+			}))),
+		),
+		Entry("should forbid to specify a shared image id and an image id",
+			api.AzureImageReference{
+				SharedGalleryImageID: pointer.StringPtr("test-shared-image-id"),
+				ID:                   "test-image-id",
+			},
+			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("storageProfile.imageReference.sharedGalleryImageID"),
 			}))),
 		),
 	)

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -290,6 +290,12 @@ func getImageReference(providerSpec *api.AzureProviderSpec) compute.ImageReferen
 		}
 	}
 
+	if imageRefClass.SharedGalleryImageID != nil {
+		return compute.ImageReference{
+			SharedGalleryImageID: imageRefClass.SharedGalleryImageID,
+		}
+	}
+
 	splits := strings.Split(*imageRefClass.URN, ":")
 	publisher := splits[0]
 	offer := splits[1]
@@ -429,7 +435,7 @@ func (d *MachinePlugin) createVMNicDisk(req *driver.CreateMachineRequest) (*comp
 	*/
 	startTime := time.Now()
 	imageRefClass := providerSpec.Properties.StorageProfile.ImageReference
-	// if ID and community id are not set the image is referenced using a URN
+	// if ID, shared id and community id are not set the image is referenced using a URN
 	if imageRefClass.URN != nil {
 		imageReference := getImageReference(providerSpec)
 		vmImage, err := clients.GetImages().Get(
@@ -500,7 +506,6 @@ func (d *MachinePlugin) createVMNicDisk(req *driver.CreateMachineRequest) (*comp
 
 	// Creating VMParameters for new VM creation request
 	VMParameters := getVMParameters(vmName, vmImageRef, *NIC.ID, providerSpec, req.Secret)
-
 	// VM creation request
 	klog.V(3).Infof("VM creation began for %q", vmName)
 	VMFuture, err := clients.GetVM().CreateOrUpdate(ctx, resourceGroupName, *VMParameters.Name, VMParameters)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add support for machines based on shared gallery images

**Which issue(s) this PR fixes**:
Fixes #71 

**Special notes for your reviewer**:
SharedGalleryImageID eg:- `/SharedGalleries/<sharedGalleryName>/Images/<sharedGalleryImageName>/Versions/<sharedGalleryImageVersionName>`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Machine-Controller-Manager Provider-Azure now supports managing virtual machines based on shared image gallery images. 
```

/invite @himanshu-kun 