### PR TITLE
Handle data disk detachment failure error

### DIFF
--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -556,7 +556,9 @@ func (d *MachinePlugin) deleteVMNicDisks(ctx context.Context, clients spi.AzureD
 	// We try to fetch the VM, detach its data disks and finally delete it
 	if vm, vmErr := clients.GetVM().Get(ctx, resourceGroupName, VMName, ""); vmErr == nil {
 
-		waitForDataDiskDetachment(ctx, clients, resourceGroupName, vm)
+		if detachmentErr := waitForDataDiskDetachment(ctx, clients, resourceGroupName, vm); detachmentErr != nil {
+			return detachmentErr
+		}
 		if deleteErr := DeleteVM(ctx, clients, resourceGroupName, VMName); deleteErr != nil {
 			return deleteErr
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR handles the error returned by the `waitForDataDiskDetachment` method, which detaches the data disk before deleting the VM itself.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
error handling is done for data disk detachment failure.
```