### PR TITLE
Fix VM creation and update when `sshAccess` is disabled.

### DIFF
--- a/pkg/azure/core_test.go
+++ b/pkg/azure/core_test.go
@@ -1949,7 +1949,7 @@ func assertVMResourcesForMachineCreation(
 			},
 			StatusCode: 404,
 		})
-		VMParameters := getVMParameters(vmName, vmImageRef, NICId, providerSpec, machineRequest.Secret)
+		VMParameters, _ := getVMParameters(vmName, vmImageRef, NICId, providerSpec, machineRequest.Secret)
 		fakeClients.VM.EXPECT().CreateOrUpdate(gomock.Any(), resourceGroupName, *VMParameters.Name, VMParameters).Return(compute.VirtualMachinesCreateOrUpdateFuture{}, *vmCreateOrUpdateError)
 	} else {
 
@@ -1959,7 +1959,7 @@ func assertVMResourcesForMachineCreation(
 			},
 			StatusCode: 404,
 		})
-		VMParameters := getVMParameters(vmName, vmImageRef, NICId, providerSpec, machineRequest.Secret)
+		VMParameters, _ := getVMParameters(vmName, vmImageRef, NICId, providerSpec, machineRequest.Secret)
 		fakeClients.VM.EXPECT().CreateOrUpdate(gomock.Any(), resourceGroupName, *VMParameters.Name, VMParameters).Return(VMFutureAPI, nil)
 	}
 }

--- a/pkg/azure/utils.go
+++ b/pkg/azure/utils.go
@@ -315,6 +315,7 @@ func getVMParameters(vmName string, image *compute.VirtualMachineImage, networkI
 				KeyData: &publicKey,
 			},
 		}
+		klog.V(3).Info("Fake SSH Public key has been set to allow VM creation")
 	}
 
 	return VMParameters, nil

--- a/pkg/azure/utils_test.go
+++ b/pkg/azure/utils_test.go
@@ -1,0 +1,28 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package azure contains the cloud provider specific implementations to manage machines
+package azure
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", func() {
+
+	Describe("PublicKey", func() {
+
+		Describe("#Generate", func() {
+			It("should properly generate PublicKey string", func() {
+				publicKey, err := generatePublicKey()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(publicKey).NotTo(Equal(""))
+			})
+		})
+	})
+})

--- a/pkg/azure/utils_test.go
+++ b/pkg/azure/utils_test.go
@@ -10,19 +10,96 @@ package azure
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+
+	api "github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/apis"
 )
 
 var _ = Describe("Utils", func() {
 
-	Describe("PublicKey", func() {
+	Describe("generateDummyPublicKey", func() {
 
-		Describe("#Generate", func() {
-			It("should properly generate PublicKey string", func() {
-				publicKey, err := generatePublicKey()
-				Expect(err).NotTo(HaveOccurred())
+		It("should properly generate PublicKey string", func() {
+			publicKey, err := generateDummyPublicKey()
+			Expect(err).NotTo(HaveOccurred())
 
-				Expect(publicKey).NotTo(Equal(""))
-			})
+			Expect(publicKey).NotTo(Equal(""))
+		})
+	})
+
+	Describe("getVMParameters", func() {
+		var vmName string
+		var networkInterfaceReferenceID string
+		var providerSpec *api.AzureProviderSpec
+		var azureProviderSecret *corev1.Secret
+
+		BeforeEach(func() {
+			vmName = "testName"
+			networkInterfaceReferenceID = "testID"
+			azureProviderSecret = &corev1.Secret{
+				Data: map[string][]byte{
+					"userData":            []byte("dummy-data"),
+					"azureClientId":       []byte("dummy-client-id"),
+					"azureClientSecret":   []byte("dummy-client-secret"),
+					"azureSubscriptionId": []byte("dummy-subcription-id"),
+					"azureTenantId":       []byte("dummy-tenant-id"),
+				},
+			}
+			providerSpec = &api.AzureProviderSpec{
+				Location: "westeurope",
+				Properties: api.AzureVirtualMachineProperties{
+					HardwareProfile: api.AzureHardwareProfile{
+						VMSize: "Standard_DS2_v2",
+					},
+					StorageProfile: api.AzureStorageProfile{
+						ImageReference: api.AzureImageReference{
+							URN: pointer.String("sap:gardenlinux:greatest:27.1.0"),
+						},
+						OsDisk: api.AzureOSDisk{
+							Caching: "None",
+							ManagedDisk: api.AzureManagedDiskParameters{
+								StorageAccountType: "Standard_LRS",
+							},
+							DiskSizeGB:   50,
+							CreateOption: "FromImage",
+						},
+						DataDisks: []api.AzureDataDisk{
+							{
+								StorageAccountType: "Standard_LRS",
+								Lun:                getInt32Pointer(1),
+								DiskSizeGB:         50,
+							},
+						},
+					},
+					OsProfile: api.AzureOSProfile{
+						AdminUsername: "core",
+						LinuxConfiguration: api.AzureLinuxConfiguration{
+							DisablePasswordAuthentication: true,
+							SSH: api.AzureSSHConfiguration{
+								PublicKeys: api.AzureSSHPublicKey{
+									Path:    "/home/core/.ssh/authorized_keys",
+									KeyData: "dummy keyData",
+								},
+							},
+						},
+					},
+					Zone: pointer.Int(2),
+				},
+				ResourceGroup: "shoot--project--seed-az",
+				SubnetInfo: api.AzureSubnetInfo{
+					VnetName:   "shoot--project--seed-az",
+					SubnetName: "shoot--project--seed-az-nodes",
+				},
+			}
+		})
+
+		It("should properly generate PublicKey when missing", func() {
+			providerSpec.Properties.OsProfile.LinuxConfiguration.SSH.PublicKeys.KeyData = ""
+			VMParameters, err := getVMParameters(vmName, nil, networkInterfaceReferenceID, providerSpec, azureProviderSecret)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect((*VMParameters.VirtualMachineProperties.OsProfile.LinuxConfiguration.SSH.PublicKeys)[0].KeyData).NotTo(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes creation and update of azure VMs when `sshAccess` is disabled by adding a "fake" `PublicKey`.

Currently, creating an azure shoot with `sshAccess` disabled is not possible since the shoot would fail in reconciliation. It fails with the following cloud provider validation error: `The value of parameter linuxConfiguration.ssh.publicKeys.keyData is invalid.` since its value is "".

After removing `SSH` from `LinuxConfiguration` it starts failing with this cloud provider error: `Authentication using either SSH or by user name and password must be enabled in Linux profile.`, which would suggest we need to provide either `SSH` or an `adminPassword`. We do not include the `adminPassword` and it is ill-advised to do so. The only option left would be to pass a "fake" `PublicKey`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy user
Fixed VM creation and update when `sshAccess` is disabled.
```