### PR TITLE
update vm delete to not wait for datadisk detachment

### DIFF
--- a/pkg/azure/core.go
+++ b/pkg/azure/core.go
@@ -12,12 +12,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gardener/machine-controller-manager-provider-azure/pkg/spi"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"k8s.io/klog/v2"
+
+	"github.com/gardener/machine-controller-manager-provider-azure/pkg/spi"
 )
 
 const (
@@ -218,8 +219,8 @@ func (d *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMac
 //
 // RESPONSE PARAMETERS (driver.ListMachinesResponse)
 // MachineList           map<string,string>  A map containing the keys as the MachineID and value as the MachineName
-//                                           for all machine's who where possibilly created by this ProviderSpec
 //
+//	for all machine's who where possibilly created by this ProviderSpec
 func (d *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachinesRequest) (*driver.ListMachinesResponse, error) {
 	// Log messages to track start and end of request
 	klog.V(2).Infof("List machines request has been received for %q", req.MachineClass.Name)

--- a/pkg/azure/mock/mockclient.go
+++ b/pkg/azure/mock/mockclient.go
@@ -99,7 +99,7 @@ func (clients *AzureDriverClients) GetClient() autorest.Client {
 // 	return clients.deployments
 // }
 
-//PluginSPIImpl is the mock implementation of PluginSPIImpl
+// PluginSPIImpl is the mock implementation of PluginSPIImpl
 type PluginSPIImpl struct {
 	AzureProviderSpec          *api.AzureProviderSpec
 	Secret                     *corev1.Secret
@@ -114,7 +114,7 @@ func NewMockPluginSPIImpl(controller *gomock.Controller) spi.SessionProviderInte
 	return &PluginSPIImpl{Controller: controller}
 }
 
-//Setup creates a compute service instance using the mock
+// Setup creates a compute service instance using the mock
 func (ms *PluginSPIImpl) Setup(secret *corev1.Secret) (spi.AzureDriverClientsInterface, error) {
 
 	if ms.azureDriverClients != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Update VM delete to not wait until all data disks are detached. This may help to prevent situations where a failed VM cannot be deleted (because detach or any operation are prohibited). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user

```