### PR TITLE
Fixed handling for data disk in tobedetached state during vm deletion

### DIFF
--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -167,18 +167,14 @@ func CheckAndDeleteLeftoverNICsAndDisks(ctx context.Context, factory access.Fact
 // Once that is set then it deletes the VM. This will ensure that no separate calls to delete each NIC and DISK are made as they will get deleted along with the VM in one single atomic call.
 func UpdateCascadeDeleteOptions(ctx context.Context, vmAccess *armcompute.VirtualMachinesClient, resourceGroup string, vm *armcompute.VirtualMachine) error {
 	vmName := *vm.Name
-	if canUpdateVirtualMachine(vm) {
-		vmUpdateParams := computeDeleteOptionUpdatesForNICsAndDisksIfRequired(resourceGroup, vm)
-		if vmUpdateParams != nil {
-			// update the VM and set cascade delete on NIC and Disks (OSDisk and DataDisks) if not already set and then trigger VM deletion.
-			klog.V(4).Infof("Updating cascade deletion options for VM: [ResourceGroup: %s, Name: %s] resources", resourceGroup, vmName)
-			err := accesshelpers.SetCascadeDeleteForNICsAndDisks(ctx, vmAccess, resourceGroup, vmName, vmUpdateParams)
-			if err != nil {
-				return status.WrapError(codes.Internal, fmt.Sprintf("Failed to update cascade delete of associated resources for VM: [ResourceGroup: %s, Name: %s], Err: %v", resourceGroup, vmName, err), err)
-			}
+	vmUpdateParams := computeDeleteOptionUpdatesForNICsAndDisksIfRequired(resourceGroup, vm)
+	if vmUpdateParams != nil {
+		// update the VM and set cascade delete on NIC and Disks (OSDisk and DataDisks) if not already set and then trigger VM deletion.
+		klog.V(4).Infof("Updating cascade deletion options for VM: [ResourceGroup: %s, Name: %s] resources", resourceGroup, vmName)
+		err := accesshelpers.SetCascadeDeleteForNICsAndDisks(ctx, vmAccess, resourceGroup, vmName, vmUpdateParams)
+		if err != nil {
+			return status.WrapError(codes.Internal, fmt.Sprintf("Failed to update cascade delete of associated resources for VM: [ResourceGroup: %s, Name: %s], Err: %v", resourceGroup, vmName, err), err)
 		}
-	} else {
-		return status.New(codes.Internal, fmt.Sprintf("Cannot update VM: [ResourceGroup: %s, Name: %s]. Either the VM has provisionState set to Failed or there are one or more data disks that are marked for detachment, update call to this VM will fail. Skipping the update call.", resourceGroup, vmName))
 	}
 	return nil
 }
@@ -198,7 +194,8 @@ func IsVirtualMachineInTerminalState(vm *armcompute.VirtualMachine) bool {
 	return vm.Properties != nil && vm.Properties.ProvisioningState != nil && strings.ToLower(*vm.Properties.ProvisioningState) == strings.ToLower(utils.ProvisioningStateFailed)
 }
 
-func canUpdateVirtualMachine(vm *armcompute.VirtualMachine) bool {
+// CanUpdateVirtualMachine checks if the VM is not in terminal state and if there are no data disks marked for detachment.
+func CanUpdateVirtualMachine(vm *armcompute.VirtualMachine) bool {
 	return !IsVirtualMachineInTerminalState(vm) && !utils.DataDisksMarkedForDetachment(vm)
 }
 

--- a/pkg/azure/provider/provider.go
+++ b/pkg/azure/provider/provider.go
@@ -141,19 +141,19 @@ func (d defaultDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMach
 			return
 		}
 	} else {
-		if helpers.IsVirtualMachineInTerminalState(vm) {
-			klog.Infof("VM: [ResourceGroup: %s, Name: %s] has ProvisionState set to Failed, will delete the VM and all its associated resources.", resourceGroup, vmName)
-			if err = helpers.DeleteVirtualMachine(ctx, vmAccess, resourceGroup, vmName); err != nil {
-				return
-			}
-			if err = helpers.CheckAndDeleteLeftoverNICsAndDisks(ctx, d.factory, vmName, connectConfig, providerSpec); err != nil {
-				return
-			}
-		} else {
+		if helpers.CanUpdateVirtualMachine(vm) {
 			if err = helpers.UpdateCascadeDeleteOptions(ctx, vmAccess, resourceGroup, vm); err != nil {
 				return
 			}
 			if err = helpers.DeleteVirtualMachine(ctx, vmAccess, resourceGroup, vmName); err != nil {
+				return
+			}
+		} else {
+			klog.Infof("Cannot update VM: [ResourceGroup: %s, Name: %s]. Either the VM has provisionState set to Failed or there are one or more data disks that are marked for detachment, update call to this VM will fail and therefore skipped. Will now delete the VM and all its associated resources.", resourceGroup, vmName)
+			if err = helpers.DeleteVirtualMachine(ctx, vmAccess, resourceGroup, vmName); err != nil {
+				return
+			}
+			if err = helpers.CheckAndDeleteLeftoverNICsAndDisks(ctx, d.factory, vmName, connectConfig, providerSpec); err != nil {
 				return
 			}
 		}

--- a/pkg/azure/provider/provider_test.go
+++ b/pkg/azure/provider/provider_test.go
@@ -351,10 +351,10 @@ func TestDeleteExistingVMWithDataDisksInDetachment(t *testing.T) {
 		MachineClass: machineClass,
 		Secret:       fakes.CreateProviderSecret(),
 	})
-	g.Expect(err).ToNot(BeNil())
-	var statusErr *status.Status
-	g.Expect(errors.As(err, &statusErr)).To(BeTrue())
-	g.Expect(statusErr.Code()).To(Equal(codes.Internal))
+	g.Expect(err).To(BeNil())
+	g.Expect(clusterState.GetVM(vmName)).To(BeNil())
+	_, ok := clusterState.MachineResourcesMap[vmName]
+	g.Expect(ok).ToNot(BeTrue())
 }
 
 func TestDeleteMachineWithInducedErrors(t *testing.T) {


### PR DESCRIPTION

**Which issue(s) this PR fixes**:
Fixes #131 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```other operator
Fixed handling for data disk in ToBeDetached=true state during vm deletion
```