### PR TITLE
Handle MarketPlaceImages with no purchase plan defined as valid case

### DIFF
--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -438,11 +438,11 @@ func ProcessVMImageConfiguration(ctx context.Context, factory access.Factory, co
 			if err != nil {
 				return
 			}
-		}
-		plan = &armcompute.Plan{
-			Name:      vmImage.Properties.Plan.Name,
-			Product:   vmImage.Properties.Plan.Product,
-			Publisher: vmImage.Properties.Plan.Publisher,
+			plan = &armcompute.Plan{
+				Name:      vmImage.Properties.Plan.Name,
+				Product:   vmImage.Properties.Plan.Product,
+				Publisher: vmImage.Properties.Plan.Publisher,
+			}
 		}
 	}
 	return imgRef, plan, nil


### PR DESCRIPTION


**Which issue(s) this PR fixes**:
Fixes #133 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Fixed the gap where VM marketplace images with no plans were not handled properly. Now one can start VMs having marketplace image with no plan.
```