### PR TITLE
Add support for vm boot diagnostic profile

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -54,6 +54,9 @@ providerSpec:
     machineSet: 
       id: <string>
       Kind: <string>
+    diagnosticsProfile:
+      enabled: false
+    # storageURI: <string>
   resourceGroup: <resource-group-name>
   subnetInfo:
     # vnetResourceGroup: <vnet-resource-group-name>

--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -106,7 +106,7 @@ type AzureVirtualMachineProperties struct {
 	VirtualMachineScaleSet *AzureSubResource `json:"virtualMachineScaleSet,omitempty"`
 	// DiagnosticsProfile specifies if boot metrics are enabled and where they are stored
 	// For additional information see: [https://learn.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics]
-	DiagnosticsProfile AzureDiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile *AzureDiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
 	// Deprecated: Use either AvailabilitySet or VirtualMachineScaleSet instead
 	MachineSet *AzureMachineSetConfig `json:"machineSet,omitempty"`
 }

--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -106,7 +106,7 @@ type AzureVirtualMachineProperties struct {
 	VirtualMachineScaleSet *AzureSubResource `json:"virtualMachineScaleSet,omitempty"`
 	// DiagnosticsProfile specifies if boot metrics are enabled and where they are stored
 	// For additional information see: [https://learn.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics]
-	DiagnosticsProfile *AzureDiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile AzureDiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
 	// Deprecated: Use either AvailabilitySet or VirtualMachineScaleSet instead
 	MachineSet *AzureMachineSetConfig `json:"machineSet,omitempty"`
 }

--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -104,6 +104,9 @@ type AzureVirtualMachineProperties struct {
 	// 3. Only `Flexible` variant of VMSS is currently supported. It is strongly recommended that consumers turn-off any
 	// autoscaling capabilities as it interferes with the lifecycle management of MCM and auto-scaling capabilities offered by Cluster-Autoscaler.
 	VirtualMachineScaleSet *AzureSubResource `json:"virtualMachineScaleSet,omitempty"`
+	// DiagnosticsProfile specifies if boot metrics are enabled and where they are stored
+	// For additional information see: [https://learn.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics]
+	DiagnosticsProfile *AzureDiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
 	// Deprecated: Use either AvailabilitySet or VirtualMachineScaleSet instead
 	MachineSet *AzureMachineSetConfig `json:"machineSet,omitempty"`
 }
@@ -265,4 +268,13 @@ type AzureSubnetInfo struct {
 	VnetResourceGroup *string `json:"vnetResourceGroup,omitempty"`
 	// SubnetName is the name of the subnet which is unique within a resource group.
 	SubnetName string `json:"subnetName,omitempty"`
+}
+
+// AzureDiagnosticsProfile specifies boot diagnostic options
+type AzureDiagnosticsProfile struct {
+	// Enabled configures boot diagnostics to be stored or not
+	Enabled bool `json:"enabled,omitempty"`
+	// StorageURI is the URI of the storage account to use for storing console output and screenshot.
+	// If not specified azure managed storage will be used.
+	StorageURI *string `json:"storageURI,omitempty"`
 }

--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -620,12 +620,7 @@ func createVMCreationParams(providerSpec api.AzureProviderSpec, imageRef armcomp
 			},
 			AvailabilitySet:        getAvailabilitySet(providerSpec.Properties.AvailabilitySet),
 			VirtualMachineScaleSet: getVirtualMachineScaleSet(providerSpec.Properties.VirtualMachineScaleSet),
-			DiagnosticsProfile: &armcompute.DiagnosticsProfile{
-				BootDiagnostics: &armcompute.BootDiagnostics{
-					Enabled:    to.Ptr(providerSpec.Properties.DiagnosticsProfile.Enabled),
-					StorageURI: providerSpec.Properties.DiagnosticsProfile.StorageURI,
-				},
-			},
+			DiagnosticsProfile:     getDiagnosticsProfile(providerSpec.Properties.DiagnosticsProfile),
 		},
 		Tags:     vmTags,
 		Zones:    getZonesFromProviderSpec(providerSpec),
@@ -732,4 +727,16 @@ func getZonesFromProviderSpec(spec api.AzureProviderSpec) []*string {
 		zones = append(zones, to.Ptr(strconv.Itoa(*spec.Properties.Zone)))
 	}
 	return zones
+}
+
+func getDiagnosticsProfile(profile *api.AzureDiagnosticsProfile) *armcompute.DiagnosticsProfile {
+	if profile == nil {
+		return nil
+	}
+	return &armcompute.DiagnosticsProfile{
+		BootDiagnostics: &armcompute.BootDiagnostics{
+			Enabled:    to.Ptr(profile.Enabled),
+			StorageURI: profile.StorageURI,
+		},
+	}
 }

--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -620,7 +620,12 @@ func createVMCreationParams(providerSpec api.AzureProviderSpec, imageRef armcomp
 			},
 			AvailabilitySet:        getAvailabilitySet(providerSpec.Properties.AvailabilitySet),
 			VirtualMachineScaleSet: getVirtualMachineScaleSet(providerSpec.Properties.VirtualMachineScaleSet),
-			DiagnosticsProfile:     getDiagnosticsProfile(providerSpec.Properties.DiagnosticsProfile),
+			DiagnosticsProfile: &armcompute.DiagnosticsProfile{
+				BootDiagnostics: &armcompute.BootDiagnostics{
+					Enabled:    to.Ptr(providerSpec.Properties.DiagnosticsProfile.Enabled),
+					StorageURI: providerSpec.Properties.DiagnosticsProfile.StorageURI,
+				},
+			},
 		},
 		Tags:     vmTags,
 		Zones:    getZonesFromProviderSpec(providerSpec),
@@ -727,16 +732,4 @@ func getZonesFromProviderSpec(spec api.AzureProviderSpec) []*string {
 		zones = append(zones, to.Ptr(strconv.Itoa(*spec.Properties.Zone)))
 	}
 	return zones
-}
-
-func getDiagnosticsProfile(profile *api.AzureDiagnosticsProfile) *armcompute.DiagnosticsProfile {
-	if profile == nil {
-		return nil
-	}
-	return &armcompute.DiagnosticsProfile{
-		BootDiagnostics: &armcompute.BootDiagnostics{
-			Enabled:    to.Ptr(profile.Enabled),
-			StorageURI: profile.StorageURI,
-		},
-	}
 }

--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -620,6 +620,7 @@ func createVMCreationParams(providerSpec api.AzureProviderSpec, imageRef armcomp
 			},
 			AvailabilitySet:        getAvailabilitySet(providerSpec.Properties.AvailabilitySet),
 			VirtualMachineScaleSet: getVirtualMachineScaleSet(providerSpec.Properties.VirtualMachineScaleSet),
+			DiagnosticsProfile:     getDiagnosticsProfile(providerSpec.Properties.DiagnosticsProfile),
 		},
 		Tags:     vmTags,
 		Zones:    getZonesFromProviderSpec(providerSpec),
@@ -726,4 +727,16 @@ func getZonesFromProviderSpec(spec api.AzureProviderSpec) []*string {
 		zones = append(zones, to.Ptr(strconv.Itoa(*spec.Properties.Zone)))
 	}
 	return zones
+}
+
+func getDiagnosticsProfile(profile *api.AzureDiagnosticsProfile) *armcompute.DiagnosticsProfile {
+	if profile == nil {
+		return nil
+	}
+	return &armcompute.DiagnosticsProfile{
+		BootDiagnostics: &armcompute.BootDiagnostics{
+			Enabled:    to.Ptr(profile.Enabled),
+			StorageURI: profile.StorageURI,
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add support to enable vm boot diagnostics

**Which issue(s) this PR fixes**:
Fixes #104 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Machine-Controller-Manager Provider-Azure now supports enabling of vm boot diagnostics. 
```