### PR TITLE
Update kubeconfig expiry to 24hrs for pipeline tests

### DIFF
--- a/.ci/pipeline_integration_test
+++ b/.ci/pipeline_integration_test
@@ -12,7 +12,7 @@ cli_path=/cc/utils/cli.py
 num_of_existing_nodes=1
 CREDENTIALS_SECRET_NAME=shoot-operator-az-team
 GARDEN_CORE_NAMESPACE=garden-core
-KUBECONFIG_EXPIRY=10800
+KUBECONFIG_EXPIRY=86400
 
 #these variables are accessed in test/integration/controller so prefixed by ${SOURCE_PATH} for absolute path
 declare CONTROL_KUBECONFIG=${SOURCE_PATH}/dev/control_kubeconfig.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Update kubeconfig expiry to 24hrs for pipeline tests

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```