### PR TITLE
Switch data disk lun from pointer to value

### DIFF
--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -197,7 +197,7 @@ type AzureDataDisk struct {
 	Name string `json:"name,omitempty"`
 	// Lun specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and
 	// therefore must be unique for each data disk attached to a VM.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun int32 `json:"lun,omitempty"`
 	// Caching specifies the caching requirements. Possible values are: None, ReadOnly, ReadWrite.
 	Caching string `json:"caching,omitempty"`
 	// StorageAccountType is the storage account type for a managed disk.

--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -197,7 +197,7 @@ type AzureDataDisk struct {
 	Name string `json:"name,omitempty"`
 	// Lun specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and
 	// therefore must be unique for each data disk attached to a VM.
-	Lun int32 `json:"lun,omitempty"`
+	Lun int32 `json:"lun"`
 	// Caching specifies the caching requirements. Possible values are: None, ReadOnly, ReadWrite.
 	Caching string `json:"caching,omitempty"`
 	// StorageAccountType is the storage account type for a managed disk.

--- a/pkg/azure/api/validation/validation.go
+++ b/pkg/azure/api/validation/validation.go
@@ -211,17 +211,14 @@ func validateDataDisks(disks []api.AzureDataDisk, fldPath *field.Path) field.Err
 
 	luns := make(map[int32]int, len(disks))
 	for _, disk := range disks {
-		if disk.Lun == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("lun"), "must provide lun"))
+		// Lun should always start from 0 and it cannot be negative. The max value of lun will depend upon the VM type to which the disks are associated.
+		// Therefore, we will avoid any max limit check for lun and delegate that responsibility to the provider as that mapping could change over time.
+		if disk.Lun < 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("lun"), disk.Lun, "lun must be a positive number"))
 		} else {
-			// Lun should always start from 0 and it cannot be negative. The max value of lun will depend upon the VM type to which the disks are associated.
-			// Therefore, we will avoid any max limit check for lun and delegate that responsibility to the provider as that mapping could change over time.
-			if *disk.Lun < 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("lun"), *disk.Lun, "lun must be a positive number"))
-			} else {
-				luns[*disk.Lun]++
-			}
+			luns[disk.Lun]++
 		}
+
 		if disk.DiskSizeGB <= 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), disk.DiskSizeGB, "DataDisk size must be positive and greater than 0"))
 		}

--- a/pkg/azure/api/validation/validation_test.go
+++ b/pkg/azure/api/validation/validation_test.go
@@ -277,30 +277,23 @@ func TestValidateDataDisks(t *testing.T) {
 		matcher        gomegatypes.GomegaMatcher
 	}{
 		{"should forbid empty storageAccountType",
-			[]api.AzureDataDisk{{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "", DiskSizeGB: 10}}, 1,
+			[]api.AzureDataDisk{{Name: "disk-1", Lun: 0, StorageAccountType: "", DiskSizeGB: 10}}, 1,
 			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.storageAccountType")}))),
 		},
 		{"should forbid negative diskSize and empty storageAccountType",
-			[]api.AzureDataDisk{{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "", DiskSizeGB: -10}}, 2,
+			[]api.AzureDataDisk{{Name: "disk-1", Lun: 0, StorageAccountType: "", DiskSizeGB: -10}}, 2,
 			ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.storageAccountType")})),
 				PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.diskSizeGB")})),
 			),
 		},
-		{
-			"should forbid nil Lun",
-			[]api.AzureDataDisk{
-				{Name: "disk-1", Lun: nil, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-			}, 1,
-			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.lun")}))),
-		},
 		{"should forbid duplicate Lun",
 			[]api.AzureDataDisk{
-				{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-2", Lun: pointer.Int32(1), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-3", Lun: pointer.Int32(0), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-4", Lun: pointer.Int32(2), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-5", Lun: pointer.Int32(1), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-1", Lun: 0, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-2", Lun: 1, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-3", Lun: 0, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-4", Lun: 2, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-5", Lun: 1, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
 			}, 2,
 			ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.lun")})),
@@ -309,9 +302,9 @@ func TestValidateDataDisks(t *testing.T) {
 		},
 		{"should succeed with non-duplicate lun, valid diskSize and non-empty storageAccountType",
 			[]api.AzureDataDisk{
-				{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-2", Lun: pointer.Int32(1), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 30},
-				{Name: "disk-3", Lun: pointer.Int32(2), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 50},
+				{Name: "disk-1", Lun: 0, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-2", Lun: 1, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 30},
+				{Name: "disk-3", Lun: 2, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 50},
 			}, 0, nil,
 		},
 	}

--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -677,7 +677,7 @@ func getDataDisks(specDataDisks []api.AzureDataDisk, vmName string) []*armcomput
 		dataDisk := &armcompute.DataDisk{
 
 			CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesEmpty),
-			Lun:          specDataDisk.Lun,
+			Lun:          to.Ptr(specDataDisk.Lun),
 			Caching:      to.Ptr(caching),
 			DeleteOption: to.Ptr(armcompute.DiskDeleteOptionTypesDelete),
 			DiskSizeGB:   pointer.Int32(specDataDisk.DiskSizeGB),

--- a/pkg/azure/testhelp/fakes/machineresources.go
+++ b/pkg/azure/testhelp/fakes/machineresources.go
@@ -443,7 +443,7 @@ func createDataDisks(spec api.AzureProviderSpec, vmName string, deleteOption *ar
 	dataDisks := make([]*armcompute.DataDisk, 0, len(specDataDisks))
 	for _, disk := range specDataDisks {
 		diskName := utils.CreateDataDiskName(vmName, disk)
-		d := createDataDisk(*disk.Lun, armcompute.CachingTypes(disk.Caching), deleteOption, disk.DiskSizeGB, armcompute.StorageAccountTypes(disk.StorageAccountType), diskName)
+		d := createDataDisk(disk.Lun, armcompute.CachingTypes(disk.Caching), deleteOption, disk.DiskSizeGB, armcompute.StorageAccountTypes(disk.StorageAccountType), diskName)
 		dataDisks = append(dataDisks, d)
 	}
 	return dataDisks

--- a/pkg/azure/testhelp/providerspec.go
+++ b/pkg/azure/testhelp/providerspec.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"k8s.io/utils/pointer"
-
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/api"
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/utils"
 )
@@ -129,7 +127,7 @@ func (b *ProviderSpecBuilder) WithDataDisks(diskName string, numDisks int) *Prov
 	for i := 0; i < numDisks; i++ {
 		d := api.AzureDataDisk{
 			Name:               diskName,
-			Lun:                pointer.Int32(int32(i)),
+			Lun:                int32(i),
 			Caching:            "None",
 			StorageAccountType: StorageAccountType,
 			DiskSizeGB:         20,

--- a/pkg/azure/utils/names.go
+++ b/pkg/azure/utils/names.go
@@ -57,7 +57,7 @@ func GetDataDiskNameSuffix(dataDisk api.AzureDataDisk) string {
 func getDataDiskInfix(dataDisk api.AzureDataDisk) string {
 	name := dataDisk.Name
 	if IsEmptyString(name) {
-		return fmt.Sprintf("%d", *dataDisk.Lun)
+		return fmt.Sprintf("%d", dataDisk.Lun)
 	}
-	return fmt.Sprintf("%s-%d", name, *dataDisk.Lun)
+	return fmt.Sprintf("%s-%d", name, dataDisk.Lun)
 }

--- a/pkg/azure/utils/names_test.go
+++ b/pkg/azure/utils/names_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/api"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
 )
 
 const vmName = "shoot--test-project-z1-4567c-xj5sq"
@@ -45,7 +44,7 @@ func TestCreateDataDiskName(t *testing.T) {
 		t.Run(entry.description, func(t *testing.T) {
 			dataDisk := api.AzureDataDisk{
 				Name:       entry.dataDiskName,
-				Lun:        pointer.Int32(entry.lun),
+				Lun:        entry.lun,
 				DiskSizeGB: 10,
 			}
 			g.Expect(CreateDataDiskName(vmName, dataDisk)).To(Equal(entry.expectedDataDiskName))


### PR DESCRIPTION
**What this PR does / why we need it**:
The documentation states that `dataDisk.Lun` is required.
Therefore it makes more sense to use a value instead of pointer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
Switch AzureDataDisk.Lun from pointer to value
```