### PR TITLE
Data disk image reference

### DIFF
--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -197,13 +197,15 @@ type AzureDataDisk struct {
 	Name string `json:"name,omitempty"`
 	// Lun specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and
 	// therefore must be unique for each data disk attached to a VM.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun int32 `json:"lun,omitempty"`
 	// Caching specifies the caching requirements. Possible values are: None, ReadOnly, ReadWrite.
 	Caching string `json:"caching,omitempty"`
 	// StorageAccountType is the storage account type for a managed disk.
 	StorageAccountType string `json:"storageAccountType,omitempty"`
 	// DiskSizeGB is the size of an empty disk in gigabytes.
 	DiskSizeGB int32 `json:"diskSizeGB,omitempty"`
+	// ImageRef optionally specifies an image source
+	ImageRef *AzureImageReference `json:"imageRef,omitempty"`
 }
 
 // AzureManagedDiskParameters is the parameters of a managed disk.

--- a/pkg/azure/api/validation/validation.go
+++ b/pkg/azure/api/validation/validation.go
@@ -211,17 +211,14 @@ func validateDataDisks(disks []api.AzureDataDisk, fldPath *field.Path) field.Err
 
 	luns := make(map[int32]int, len(disks))
 	for _, disk := range disks {
-		if disk.Lun == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("lun"), "must provide lun"))
+		// Lun should always start from 0 and it cannot be negative. The max value of lun will depend upon the VM type to which the disks are associated.
+		// Therefore, we will avoid any max limit check for lun and delegate that responsibility to the provider as that mapping could change over time.
+		if disk.Lun < 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("lun"), disk.Lun, "lun must be a positive number"))
 		} else {
-			// Lun should always start from 0 and it cannot be negative. The max value of lun will depend upon the VM type to which the disks are associated.
-			// Therefore, we will avoid any max limit check for lun and delegate that responsibility to the provider as that mapping could change over time.
-			if *disk.Lun < 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("lun"), *disk.Lun, "lun must be a positive number"))
-			} else {
-				luns[*disk.Lun]++
-			}
+			luns[disk.Lun]++
 		}
+
 		if disk.DiskSizeGB <= 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), disk.DiskSizeGB, "DataDisk size must be positive and greater than 0"))
 		}

--- a/pkg/azure/api/validation/validation_test.go
+++ b/pkg/azure/api/validation/validation_test.go
@@ -277,30 +277,23 @@ func TestValidateDataDisks(t *testing.T) {
 		matcher        gomegatypes.GomegaMatcher
 	}{
 		{"should forbid empty storageAccountType",
-			[]api.AzureDataDisk{{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "", DiskSizeGB: 10}}, 1,
+			[]api.AzureDataDisk{{Name: "disk-1", Lun: 0, StorageAccountType: "", DiskSizeGB: 10}}, 1,
 			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.storageAccountType")}))),
 		},
 		{"should forbid negative diskSize and empty storageAccountType",
-			[]api.AzureDataDisk{{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "", DiskSizeGB: -10}}, 2,
+			[]api.AzureDataDisk{{Name: "disk-1", Lun: 0, StorageAccountType: "", DiskSizeGB: -10}}, 2,
 			ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.storageAccountType")})),
 				PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.diskSizeGB")})),
 			),
 		},
-		{
-			"should forbid nil Lun",
-			[]api.AzureDataDisk{
-				{Name: "disk-1", Lun: nil, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-			}, 1,
-			ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.lun")}))),
-		},
 		{"should forbid duplicate Lun",
 			[]api.AzureDataDisk{
-				{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-2", Lun: pointer.Int32(1), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-3", Lun: pointer.Int32(0), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-4", Lun: pointer.Int32(2), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-5", Lun: pointer.Int32(1), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-1", Lun: 0, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-2", Lun: 1, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-3", Lun: 0, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-4", Lun: 2, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-5", Lun: 1, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
 			}, 2,
 			ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeInvalid), "Field": Equal("providerSpec.properties.storageProfile.dataDisks.lun")})),
@@ -309,9 +302,9 @@ func TestValidateDataDisks(t *testing.T) {
 		},
 		{"should succeed with non-duplicate lun, valid diskSize and non-empty storageAccountType",
 			[]api.AzureDataDisk{
-				{Name: "disk-1", Lun: pointer.Int32(0), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
-				{Name: "disk-2", Lun: pointer.Int32(1), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 30},
-				{Name: "disk-3", Lun: pointer.Int32(2), StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 50},
+				{Name: "disk-1", Lun: 0, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 10},
+				{Name: "disk-2", Lun: 1, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 30},
+				{Name: "disk-3", Lun: 2, StorageAccountType: "StandardSSD_LRS", DiskSizeGB: 50},
 			}, 0, nil,
 		},
 	}

--- a/pkg/azure/provider/helpers/resourcegraphprocessor.go
+++ b/pkg/azure/provider/helpers/resourcegraphprocessor.go
@@ -120,7 +120,7 @@ func getDataDiskNameSuffixes(providerSpec api.AzureProviderSpec) sets.Set[string
 	dataDisks := providerSpec.Properties.StorageProfile.DataDisks
 	if dataDisks != nil {
 		for _, dataDisk := range dataDisks {
-			dataDiskNameSuffixes.Insert(utils.GetDataDiskNameSuffix(dataDisk))
+			dataDiskNameSuffixes.Insert(utils.GetDataDiskNameSuffix(dataDisk.Name, dataDisk.Lun))
 		}
 	}
 	return dataDiskNameSuffixes

--- a/pkg/azure/provider/provider.go
+++ b/pkg/azure/provider/provider.go
@@ -69,6 +69,7 @@ func (d defaultDriver) CreateMachine(ctx context.Context, req *driver.CreateMach
 	if err != nil {
 		return
 	}
+
 	subnet, err := helpers.GetSubnet(ctx, d.factory, connectConfig, providerSpec)
 	if err != nil {
 		return
@@ -79,10 +80,18 @@ func (d defaultDriver) CreateMachine(ctx context.Context, req *driver.CreateMach
 		return
 	}
 
-	vm, err := helpers.CreateVM(ctx, d.factory, connectConfig, providerSpec, imageReference, plan, req.Secret, nicID, vmName)
+	// create disks with image ref since they can not be created together with the vm
+	// TODO parallelize creation with nic?
+	imageRefDisks, err := helpers.CreateDisksWithImageRef(ctx, d.factory, connectConfig, providerSpec, vmName)
 	if err != nil {
 		return
 	}
+
+	vm, err := helpers.CreateVM(ctx, d.factory, connectConfig, providerSpec, imageReference, plan, req.Secret, nicID, vmName, imageRefDisks)
+	if err != nil {
+		return
+	}
+
 	resp = helpers.ConstructCreateMachineResponse(providerSpec.Location, vmName)
 	helpers.LogVMCreation(providerSpec.Location, providerSpec.ResourceGroup, vm)
 	return

--- a/pkg/azure/testhelp/fakes/machineresources.go
+++ b/pkg/azure/testhelp/fakes/machineresources.go
@@ -294,7 +294,7 @@ func createDataDiskResources(spec api.AzureProviderSpec, vmID *string, vmName st
 	dataDisks := make(map[string]*armcompute.Disk, len(specDataDisks))
 	if specDataDisks != nil {
 		for _, specDataDisk := range specDataDisks {
-			diskName := utils.CreateDataDiskName(vmName, specDataDisk)
+			diskName := utils.CreateDataDiskName(vmName, specDataDisk.Name, specDataDisk.Lun)
 			dataDisks[diskName] = createDiskResource(spec, diskName, vmID, nil)
 		}
 	}
@@ -442,8 +442,8 @@ func createDataDisks(spec api.AzureProviderSpec, vmName string, deleteOption *ar
 	}
 	dataDisks := make([]*armcompute.DataDisk, 0, len(specDataDisks))
 	for _, disk := range specDataDisks {
-		diskName := utils.CreateDataDiskName(vmName, disk)
-		d := createDataDisk(*disk.Lun, armcompute.CachingTypes(disk.Caching), deleteOption, disk.DiskSizeGB, armcompute.StorageAccountTypes(disk.StorageAccountType), diskName)
+		diskName := utils.CreateDataDiskName(vmName, disk.Name, disk.Lun)
+		d := createDataDisk(disk.Lun, armcompute.CachingTypes(disk.Caching), deleteOption, disk.DiskSizeGB, armcompute.StorageAccountTypes(disk.StorageAccountType), diskName)
 		dataDisks = append(dataDisks, d)
 	}
 	return dataDisks

--- a/pkg/azure/testhelp/providerspec.go
+++ b/pkg/azure/testhelp/providerspec.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"k8s.io/utils/pointer"
-
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/api"
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/utils"
 )
@@ -129,7 +127,7 @@ func (b *ProviderSpecBuilder) WithDataDisks(diskName string, numDisks int) *Prov
 	for i := 0; i < numDisks; i++ {
 		d := api.AzureDataDisk{
 			Name:               diskName,
-			Lun:                pointer.Int32(int32(i)),
+			Lun:                int32(i),
 			Caching:            "None",
 			StorageAccountType: StorageAccountType,
 			DiskSizeGB:         20,
@@ -193,7 +191,7 @@ func (b *ProviderSpecBuilder) Build() api.AzureProviderSpec {
 func CreateDataDiskNames(vmName string, spec api.AzureProviderSpec) []string {
 	var diskNames []string
 	for _, specDataDisk := range spec.Properties.StorageProfile.DataDisks {
-		diskNames = append(diskNames, utils.CreateDataDiskName(vmName, specDataDisk))
+		diskNames = append(diskNames, utils.CreateDataDiskName(vmName, specDataDisk.Name, specDataDisk.Lun))
 	}
 	return diskNames
 }

--- a/pkg/azure/utils/names.go
+++ b/pkg/azure/utils/names.go
@@ -6,8 +6,6 @@ package utils
 
 import (
 	"fmt"
-
-	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/api"
 )
 
 const (
@@ -42,22 +40,21 @@ func CreateOSDiskName(vmName string) string {
 }
 
 // CreateDataDiskName creates a name for a DataDisk using VM name and data disk name specified in the provider Spec
-func CreateDataDiskName(vmName string, dataDisk api.AzureDataDisk) string {
+func CreateDataDiskName(vmName, diskName string, lun int32) string {
 	prefix := vmName
-	suffix := GetDataDiskNameSuffix(dataDisk)
+	suffix := GetDataDiskNameSuffix(diskName, lun)
 	return fmt.Sprintf("%s%s", prefix, suffix)
 }
 
 // GetDataDiskNameSuffix creates the suffix based on an optional data disk name and required lun fields.
-func GetDataDiskNameSuffix(dataDisk api.AzureDataDisk) string {
-	infix := getDataDiskInfix(dataDisk)
+func GetDataDiskNameSuffix(diskName string, lun int32) string {
+	infix := getDataDiskInfix(diskName, lun)
 	return fmt.Sprintf("-%s%s", infix, DataDiskSuffix)
 }
 
-func getDataDiskInfix(dataDisk api.AzureDataDisk) string {
-	name := dataDisk.Name
-	if IsEmptyString(name) {
-		return fmt.Sprintf("%d", *dataDisk.Lun)
+func getDataDiskInfix(diskName string, lun int32) string {
+	if IsEmptyString(diskName) {
+		return fmt.Sprintf("%d", lun)
 	}
-	return fmt.Sprintf("%s-%d", name, *dataDisk.Lun)
+	return fmt.Sprintf("%s-%d", diskName, lun)
 }

--- a/pkg/azure/utils/names_test.go
+++ b/pkg/azure/utils/names_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/api"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/pointer"
 )
 
 const vmName = "shoot--test-project-z1-4567c-xj5sq"
@@ -45,10 +44,10 @@ func TestCreateDataDiskName(t *testing.T) {
 		t.Run(entry.description, func(t *testing.T) {
 			dataDisk := api.AzureDataDisk{
 				Name:       entry.dataDiskName,
-				Lun:        pointer.Int32(entry.lun),
+				Lun:        entry.lun,
 				DiskSizeGB: 10,
 			}
-			g.Expect(CreateDataDiskName(vmName, dataDisk)).To(Equal(entry.expectedDataDiskName))
+			g.Expect(CreateDataDiskName(vmName, dataDisk.Name, dataDisk.Lun)).To(Equal(entry.expectedDataDiskName))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to attach dataDisks with image references

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It's not possible to create a dataDisk with imageReference afaik.
Therefore we create a general Disk with the imageReference before creating the VM.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Adds the ability to attach dataDisks with image references
```