### PR TITLE
Always use passed ConnectConfig when creating clients

### DIFF
--- a/pkg/azure/access/factory.go
+++ b/pkg/azure/access/factory.go
@@ -54,7 +54,7 @@ func (f defaultFactory) GetResourceGroupsAccess(connectConfig ConnectConfig) (*a
 	if err != nil {
 		return nil, err
 	}
-	return armresources.NewResourceGroupsClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armresources.NewResourceGroupsClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetVirtualMachinesAccess(connectConfig ConnectConfig) (*armcompute.VirtualMachinesClient, error) {
@@ -62,7 +62,7 @@ func (f defaultFactory) GetVirtualMachinesAccess(connectConfig ConnectConfig) (*
 	if err != nil {
 		return nil, err
 	}
-	return armcompute.NewVirtualMachinesClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armcompute.NewVirtualMachinesClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetNetworkInterfacesAccess(connectConfig ConnectConfig) (*armnetwork.InterfacesClient, error) {
@@ -70,7 +70,7 @@ func (f defaultFactory) GetNetworkInterfacesAccess(connectConfig ConnectConfig) 
 	if err != nil {
 		return nil, err
 	}
-	return armnetwork.NewInterfacesClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armnetwork.NewInterfacesClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetSubnetAccess(connectConfig ConnectConfig) (*armnetwork.SubnetsClient, error) {
@@ -78,7 +78,7 @@ func (f defaultFactory) GetSubnetAccess(connectConfig ConnectConfig) (*armnetwor
 	if err != nil {
 		return nil, err
 	}
-	return armnetwork.NewSubnetsClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armnetwork.NewSubnetsClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetDisksAccess(connectConfig ConnectConfig) (*armcompute.DisksClient, error) {
@@ -86,7 +86,7 @@ func (f defaultFactory) GetDisksAccess(connectConfig ConnectConfig) (*armcompute
 	if err != nil {
 		return nil, err
 	}
-	return armcompute.NewDisksClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armcompute.NewDisksClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetResourceGraphAccess(connectConfig ConnectConfig) (*armresourcegraph.Client, error) {
@@ -94,7 +94,7 @@ func (f defaultFactory) GetResourceGraphAccess(connectConfig ConnectConfig) (*ar
 	if err != nil {
 		return nil, err
 	}
-	return armresourcegraph.NewClient(tokenCredential, f.clientOptions)
+	return armresourcegraph.NewClient(tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetVirtualMachineImagesAccess(connectConfig ConnectConfig) (*armcompute.VirtualMachineImagesClient, error) {
@@ -102,7 +102,7 @@ func (f defaultFactory) GetVirtualMachineImagesAccess(connectConfig ConnectConfi
 	if err != nil {
 		return nil, err
 	}
-	return armcompute.NewVirtualMachineImagesClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armcompute.NewVirtualMachineImagesClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }
 
 func (f defaultFactory) GetMarketPlaceAgreementsAccess(connectConfig ConnectConfig) (*armmarketplaceordering.MarketplaceAgreementsClient, error) {
@@ -110,5 +110,5 @@ func (f defaultFactory) GetMarketPlaceAgreementsAccess(connectConfig ConnectConf
 	if err != nil {
 		return nil, err
 	}
-	return armmarketplaceordering.NewMarketplaceAgreementsClient(connectConfig.SubscriptionID, tokenCredential, f.clientOptions)
+	return armmarketplaceordering.NewMarketplaceAgreementsClient(connectConfig.SubscriptionID, tokenCredential, &arm.ClientOptions{ClientOptions: connectConfig.ClientOptions})
 }

--- a/pkg/azure/access/factory.go
+++ b/pkg/azure/access/factory.go
@@ -21,21 +21,13 @@ type TokenCredentialProvider func(connectConfig ConnectConfig) (azcore.TokenCred
 
 // defaultFactory implements Factory interface.
 type defaultFactory struct {
-	clientOptions           *arm.ClientOptions
 	tokenCredentialProvider TokenCredentialProvider
 }
 
 // NewDefaultAccessFactory creates a new instance of Factory.
 func NewDefaultAccessFactory() Factory {
-	return NewAccessFactoryWithOptions(nil, GetDefaultTokenCredentials)
-}
-
-// NewAccessFactoryWithOptions creates an instance of Factory which uses a fixed tokenCredential
-// passed as an argument and also takes custom arm.ClientOptions.
-func NewAccessFactoryWithOptions(clientOptions *arm.ClientOptions, tokenCredentialProvider TokenCredentialProvider) Factory {
 	return defaultFactory{
-		clientOptions:           clientOptions,
-		tokenCredentialProvider: tokenCredentialProvider,
+		tokenCredentialProvider: GetDefaultTokenCredentials,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow-up to #148. Due to an oversight, the previous change caused only the authentication to connect to the intended cloud.

I've obtained some credentials for other Instances in the meantime and was able to verify that with these changes, creating Machines on other Providers can succeed.

**Special notes for your reviewer**:
I've gone ahead and made the passed ConnectConfig the source of truth for the connection-options. One could think about merging it with the factory-provided options, but since these are currently _always_ the default options I've decided not to do this for now.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy user
Fixed a bug that prevented everything but authentication from connecting to non-public Azure Cloud instances.
```