### PR TITLE
Map Azure error codes to `ResourceExhausted` error code

### DIFF
--- a/pkg/azure/access/errors/errors.go
+++ b/pkg/azure/access/errors/errors.go
@@ -19,6 +19,8 @@ import (
 const (
 	// ZonalAllocationFailedAzErrorCode is an Azure error code indicating that there is insufficient capacity in the target zone.
 	ZonalAllocationFailedAzErrorCode = "ZonalAllocationFailed"
+	// SkuNotAvailableAzErrorCode is an Azure error code that indicates the specific resource SKU (e.g., a virtual machine size) selected isn't currently available.
+	SkuNotAvailableAzErrorCode = "SkuNotAvailable"
 	// CorrelationRequestIDAzHeaderKey is the Azure API response header key whose value is a request correlation ID.
 	CorrelationRequestIDAzHeaderKey = "x-ms-correlation-request-id"
 	// RequestIDAzHeaderKey is the Azure API response header key whose value is the request ID.
@@ -84,7 +86,7 @@ func GetMatchingErrorCode(err error) codes.Code {
 	if errors.As(err, &respErr) {
 		azErrorCode := respErr.ErrorCode
 		switch azErrorCode {
-		case ZonalAllocationFailedAzErrorCode:
+		case ZonalAllocationFailedAzErrorCode, SkuNotAvailableAzErrorCode:
 			return codes.ResourceExhausted
 		default:
 			return codes.Internal

--- a/pkg/azure/access/errors/errors.go
+++ b/pkg/azure/access/errors/errors.go
@@ -23,6 +23,8 @@ const (
 	SkuNotAvailableAzErrorCode = "SkuNotAvailable"
 	// AllocationFailedAzErrorCode is an Azure error code that indicates that there is insufficient capacity in the region
 	AllocationFailedAzErrorCode = "AllocationFailed"
+	// ResourceQuotaExceededAzErrorCode is an Azure error code that indicates that the quota has exceeded for a subscription, resource group, or error code
+	ResourceQuotaExceededAzErrorCode = "ResourceQuotaExceeded"
 	// CorrelationRequestIDAzHeaderKey is the Azure API response header key whose value is a request correlation ID.
 	CorrelationRequestIDAzHeaderKey = "x-ms-correlation-request-id"
 	// RequestIDAzHeaderKey is the Azure API response header key whose value is the request ID.
@@ -88,7 +90,7 @@ func GetMatchingErrorCode(err error) codes.Code {
 	if errors.As(err, &respErr) {
 		azErrorCode := respErr.ErrorCode
 		switch azErrorCode {
-		case ZonalAllocationFailedAzErrorCode, SkuNotAvailableAzErrorCode, AllocationFailedAzErrorCode:
+		case ZonalAllocationFailedAzErrorCode, SkuNotAvailableAzErrorCode, AllocationFailedAzErrorCode, ResourceQuotaExceededAzErrorCode:
 			return codes.ResourceExhausted
 		default:
 			return codes.Internal

--- a/pkg/azure/access/errors/errors.go
+++ b/pkg/azure/access/errors/errors.go
@@ -21,6 +21,8 @@ const (
 	ZonalAllocationFailedAzErrorCode = "ZonalAllocationFailed"
 	// SkuNotAvailableAzErrorCode is an Azure error code that indicates the specific resource SKU (e.g., a virtual machine size) selected isn't currently available.
 	SkuNotAvailableAzErrorCode = "SkuNotAvailable"
+	// AllocationFailedAzErrorCode is an Azure error code that indicates that there is insufficient capacity in the region
+	AllocationFailedAzErrorCode = "AllocationFailed"
 	// CorrelationRequestIDAzHeaderKey is the Azure API response header key whose value is a request correlation ID.
 	CorrelationRequestIDAzHeaderKey = "x-ms-correlation-request-id"
 	// RequestIDAzHeaderKey is the Azure API response header key whose value is the request ID.
@@ -86,7 +88,7 @@ func GetMatchingErrorCode(err error) codes.Code {
 	if errors.As(err, &respErr) {
 		azErrorCode := respErr.ErrorCode
 		switch azErrorCode {
-		case ZonalAllocationFailedAzErrorCode, SkuNotAvailableAzErrorCode:
+		case ZonalAllocationFailedAzErrorCode, SkuNotAvailableAzErrorCode, AllocationFailedAzErrorCode:
 			return codes.ResourceExhausted
 		default:
 			return codes.Internal


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR maps the following errors returned by Azure during VM creation to the `ResourceExhausted` error code.
1. SkuNotAvailable
2. AllocationFailed
3. ResourceQuotaExceeded

**Which issue(s) this PR fixes**:
Fixes #187 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
SkuNotAvailable error is now mapped to ResourceExhausted error code
```
```improvement operator
AllocationFailed error is now mapped to ResourceExhausted error code
```
```improvement operator
ResourceQuotaExceeded error is now mapped to ResourceExhausted error code
```