### PR TITLE
Orphan Safety Controller missing VM's due to large resource query

### DIFF
--- a/pkg/azure/access/helpers/resourcegraph.go
+++ b/pkg/azure/access/helpers/resourcegraph.go
@@ -29,32 +29,51 @@ func QueryAndMap[T any](ctx context.Context, client *armresourcegraph.Client, su
 	defer instrument.AZAPIMetricRecorderFn(resourceGraphQueryServiceLabel, &err)()
 
 	query := fmt.Sprintf(queryTemplate, templateArgs...)
-	resources, err := client.Resources(ctx,
-		armresourcegraph.QueryRequest{
+	var skipToken *string
+
+	// Continue fetching results while there is a skipToken
+	for {
+		queryRequest := armresourcegraph.QueryRequest{
 			Query:         to.Ptr(query),
 			Options:       nil,
 			Subscriptions: []*string{to.Ptr(subscriptionID)},
-		}, nil)
+		}
 
-	if err != nil {
-		errors.LogAzAPIError(err, "ResourceGraphQuery failure to execute Query: %s", query)
-		return nil, err
-	}
-
-	if resources.TotalRecords == pointer.Int64(0) {
-		return results, nil
-	}
-
-	// resourceResponse.Data is a []interface{}
-	if objSlice, ok := resources.Data.([]interface{}); ok {
-		for _, obj := range objSlice {
-			// Each obj in resourceResponse.Data is a map[string]Interface{}
-			rowElements := obj.(map[string]interface{})
-			result := mapperFn(rowElements)
-			if result != nil {
-				results = append(results, *result)
+		// Set skipToken in options if present for subsequent pages
+		if skipToken != nil {
+			queryRequest.Options = &armresourcegraph.QueryRequestOptions{
+				SkipToken: skipToken,
 			}
 		}
+
+		resources, err := client.Resources(ctx, queryRequest, nil)
+		if err != nil {
+			errors.LogAzAPIError(err, "ResourceGraphQuery failure to execute Query: %s", query)
+			return nil, err
+		}
+
+		if resources.TotalRecords == pointer.Int64(0) {
+			return results, nil
+		}
+
+		// resourceResponse.Data is a []interface{}
+		if objSlice, ok := resources.Data.([]interface{}); ok {
+			for _, obj := range objSlice {
+				// Each obj in resourceResponse.Data is a map[string]Interface{}
+				rowElements := obj.(map[string]interface{})
+				result := mapperFn(rowElements)
+				if result != nil {
+					results = append(results, *result)
+				}
+			}
+		}
+
+		// Check if there are more pages to fetch and set skipToken for next iteration
+		if resources.SkipToken == nil || *resources.SkipToken == "" {
+			break
+		}
+		skipToken = resources.SkipToken
 	}
-	return
+
+	return results, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**
This pull request adds pagination logic in the `QueryAndMap` function within `pkg/azure/access/helpers/resourcegraph.go`, ensuring all results are retrieved from the Azure Resource Graph API instead of just the first page.

**Which issue(s) this PR  #fixes**:
Fixes #202 (?)

Enhancements to pagination and result handling:
* Modified the query execution loop to repeatedly fetch results using the [`skipToken`](https://learn.microsoft.com/en-us/rest/api/azureresourcegraph/resourcegraph/resources/resources?view=rest-azureresourcegraph-resourcegraph-2022-10-01&tabs=HTTP#next-page-query), handling paginated responses from the Resource Graph API until all pages are processed.
* Updated the function to accumulate results across all pages and return the complete set, rather than returning after the first page.

**Special notes for your reviewer**:
~~Passed unit tests~~
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Fixed an issue in the orphan safety controller where orphaned VM instances were not fully cleaned up in large Azure clusters due to missing pagination in Azure Resource Graph queries.
```