### PR TITLE
Fetch GNA secret when running IT locally

### DIFF
--- a/.ci/local_integration_test
+++ b/.ci/local_integration_test
@@ -14,7 +14,7 @@ declare TARGET_CLUSTER
 declare CONTROL_CLUSTER
 declare GARDEN_CORE_NAMESPACE
 declare CONTROL_KUBECONFIG
-DEFAULT_MCM_REPO_PATH=$(realpath "$(pwd)/../machine-controller-manager")
+declare GNA_SECRET_NAME
 DEFAULT_MCM_REPO_PATH=$(realpath "$(pwd)/../machine-controller-manager")
 
 
@@ -237,6 +237,13 @@ fi
 
 set -o allexport
 source .env
+printf "\e[33mFetching the gardener-node-agent secret name. (If gardener-node-agent authorizer webhook is enabled, then this value is compulsory. Link to PR:https://github.com/gardener/gardener/pull/10535. The value can be found in machineClass.providerSpec.tags/labels. \e[0m\n"
+GNA_SECRET_NAME=$(kubectl --kubeconfig=$CONTROL_KUBECONFIG get mcc -n $CONTROL_CLUSTER_NAMESPACE -o jsonpath='{.items[0].providerSpec.tags.worker\.gardener\.cloud_gardener-node-agent-secret-name}')
+if [ -z "GNA_SECRET_NAME" ]
+then
+    printf "\e[31m GNA Secret name is empty\e[0m\n"
+fi
+export GNA_SECRET_NAME=$GNA_SECRET_NAME
 set +o allexport
 
 CREDENTIALS_SECRET_NAME=shoot-operator-az-team


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the local integration test script to fetch GNA secret name when running tests.
This is needed when running IT in a gardener cluster with with the gardener-node-agent setup. Without this, nodes will not be able to join the cluster

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user

```