### PR TITLE
add support for specifying diskControllerType during VM creation

### DIFF
--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -163,6 +163,8 @@ type AzureMachineSetConfig struct {
 type AzureStorageProfile struct {
 	// ImageReference specifies information about the image to use. One can specify information about platform images, marketplace images, or virtual machine images.
 	ImageReference AzureImageReference `json:"imageReference,omitempty"`
+	// DiskControllerType specifies the disk controller type configured for the VM. Possible values are: SCSI, NVMe.
+	DiskControllerType string `json:"diskControllerType,omitempty"`
 	// OsDisk contains the information about the operating system disk used by the VM.
 	// See [https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#os-disk].
 	OsDisk AzureOSDisk `json:"osDisk,omitempty"`

--- a/pkg/azure/api/providerspec.go
+++ b/pkg/azure/api/providerspec.go
@@ -164,6 +164,9 @@ type AzureStorageProfile struct {
 	// ImageReference specifies information about the image to use. One can specify information about platform images, marketplace images, or virtual machine images.
 	ImageReference AzureImageReference `json:"imageReference,omitempty"`
 	// DiskControllerType specifies the disk controller type configured for the VM. Possible values are: SCSI, NVMe.
+	// Not all VM types support NVMe and in case the user selects NVMe for a VM type that does not support it, the deployment will fail
+	// Furthermore, the VM image used for VM deployments has to support it as well.
+	// For more information, see https://learn.microsoft.com/azure/virtual-machines/nvme-overview
 	DiskControllerType string `json:"diskControllerType,omitempty"`
 	// OsDisk contains the information about the operating system disk used by the VM.
 	// See [https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#os-disk].

--- a/pkg/azure/api/validation/validation.go
+++ b/pkg/azure/api/validation/validation.go
@@ -190,7 +190,7 @@ func validateDiskControllerType(diskControllerType string, fldPath *field.Path) 
 		return allErrs
 	}
 
-	validValues := []string{"SCSI", "NVMe"}
+	validValues := stringTypesToString(armcompute.PossibleDiskControllerTypesValues())
 	if ok := isValidEnumString(diskControllerType, validValues); !ok {
 		allErrs = append(allErrs, field.NotSupported(fldPath, diskControllerType, validValues))
 	}

--- a/pkg/azure/api/validation/validation.go
+++ b/pkg/azure/api/validation/validation.go
@@ -177,8 +177,24 @@ func validateHardwareProfile(hwProfile api.AzureHardwareProfile, fldPath *field.
 func validateStorageProfile(storageProfile api.AzureStorageProfile, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, validateStorageImageRef(storageProfile.ImageReference, fldPath.Child("imageReference"))...)
+	allErrs = append(allErrs, validateDiskControllerType(storageProfile.DiskControllerType, fldPath.Child("diskControllerType"))...)
 	allErrs = append(allErrs, validateOSDisk(storageProfile.OsDisk, fldPath.Child("osDisk"))...)
 	allErrs = append(allErrs, validateDataDisks(storageProfile.DataDisks, fldPath.Child("dataDisks"))...)
+	return allErrs
+}
+
+func validateDiskControllerType(diskControllerType string, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if utils.IsEmptyString(diskControllerType) {
+		return allErrs
+	}
+
+	validValues := []string{"SCSI", "NVMe"}
+	if ok := isValidEnumString(diskControllerType, validValues); !ok {
+		allErrs = append(allErrs, field.NotSupported(fldPath, diskControllerType, validValues))
+	}
+
 	return allErrs
 }
 

--- a/pkg/azure/api/validation/validation_test.go
+++ b/pkg/azure/api/validation/validation_test.go
@@ -186,6 +186,12 @@ func TestValidateStorageProfile(t *testing.T) {
 	storageProfile.DiskControllerType = "NVMe"
 	g.Expect(validateStorageProfile(storageProfile, fldPath)).To(BeEmpty())
 
+	storageProfile.DiskControllerType = "SCSI"
+	g.Expect(validateStorageProfile(storageProfile, fldPath)).To(BeEmpty())
+
+	storageProfile.DiskControllerType = ""
+	g.Expect(validateStorageProfile(storageProfile, fldPath)).To(BeEmpty())
+
 	storageProfile.DiskControllerType = "unknown"
 	g.Expect(validateStorageProfile(storageProfile, fldPath)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeNotSupported), "Field": Equal("providerSpec.properties.storageProfile.diskControllerType")}))))
 }

--- a/pkg/azure/api/validation/validation_test.go
+++ b/pkg/azure/api/validation/validation_test.go
@@ -172,6 +172,24 @@ func TestValidateHardwareProfile(t *testing.T) {
 	g.Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeRequired), "Field": Equal("providerSpec.properties.hardwareProfile.vmSize")}))))
 }
 
+func TestValidateStorageProfile(t *testing.T) {
+	fldPath := field.NewPath("providerSpec.properties.storageProfile")
+	storageProfile := api.AzureStorageProfile{
+		ImageReference: api.AzureImageReference{URN: ptr.To("publisher:offer:sku:version")},
+		OsDisk: api.AzureOSDisk{
+			DiskSizeGB:   20,
+			CreateOption: "FromImage",
+		},
+	}
+
+	g := NewWithT(t)
+	storageProfile.DiskControllerType = "NVMe"
+	g.Expect(validateStorageProfile(storageProfile, fldPath)).To(BeEmpty())
+
+	storageProfile.DiskControllerType = "unknown"
+	g.Expect(validateStorageProfile(storageProfile, fldPath)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{"Type": Equal(field.ErrorTypeNotSupported), "Field": Equal("providerSpec.properties.storageProfile.diskControllerType")}))))
+}
+
 func TestValidateOSDisk(t *testing.T) {
 	fldPath := field.NewPath("providerSpec.properties.storageProfile.osDisk")
 	table := []struct {

--- a/pkg/azure/provider/helpers/driver.go
+++ b/pkg/azure/provider/helpers/driver.go
@@ -755,6 +755,10 @@ func createVMCreationParams(providerSpec api.AzureProviderSpec, imageRef armcomp
 		Identity: getVMIdentity(providerSpec.Properties.IdentityID),
 	}
 
+	if diskControllerType := providerSpec.Properties.StorageProfile.DiskControllerType; diskControllerType != "" {
+		vm.Properties.StorageProfile.DiskControllerType = to.Ptr(armcompute.DiskControllerTypes(diskControllerType))
+	}
+
 	// Processing for CVMs
 	if securityProfile := providerSpec.Properties.SecurityProfile; securityProfile != nil {
 		vm.Properties.SecurityProfile = &armcompute.SecurityProfile{}

--- a/pkg/azure/provider/helpers/driver_test.go
+++ b/pkg/azure/provider/helpers/driver_test.go
@@ -8,17 +8,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
-	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/access"
-	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/testhelp/fakes"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
-	corev1 "k8s.io/api/core/v1"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/access"
 	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/testhelp"
-	. "github.com/onsi/gomega"
-
+	"github.com/gardener/machine-controller-manager-provider-azure/pkg/azure/testhelp/fakes"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestDeriveInstanceID(t *testing.T) {
@@ -83,6 +83,7 @@ func TestCreateVM(t *testing.T) {
 		description            string
 		VMNamesForTestSetup    []string
 		targetVMName           string
+		diskControllerType     string
 		shouldOperationSucceed bool
 		vmAccessApiBehavior    *fakes.APIBehaviorSpec
 		nicAccessApiBehavior   *fakes.APIBehaviorSpec
@@ -93,6 +94,7 @@ func TestCreateVM(t *testing.T) {
 			description:            "should successfully create a VM",
 			VMNamesForTestSetup:    []string{"vm-1"},
 			targetVMName:           "vm-1",
+			diskControllerType:     "NVMe",
 			shouldOperationSucceed: true,
 			vmAccessApiBehavior:    nil,
 			nicAccessApiBehavior:   nil,
@@ -185,6 +187,7 @@ func TestCreateVM(t *testing.T) {
 		t.Run(entry.description, func(_ *testing.T) {
 			// Build Provider Spec
 			providerSpec := testhelp.NewProviderSpecBuilder(testResourceGroupName, testShootNs, testWorkerPool0Name).WithDefaultValues().Build()
+			providerSpec.Properties.StorageProfile.DiskControllerType = entry.diskControllerType
 
 			// Create cluster state
 			clusterState := fakes.NewClusterState(providerSpec)
@@ -217,6 +220,11 @@ func TestCreateVM(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(vm).NotTo(BeNil())
 				g.Expect(*vm.Name).To(Equal(entry.targetVMName))
+				if entry.diskControllerType != "" {
+					g.Expect(vm.Properties.StorageProfile.DiskControllerType).To(PointTo(Equal(armcompute.DiskControllerTypes(entry.diskControllerType))))
+				} else {
+					g.Expect(vm.Properties.StorageProfile.DiskControllerType).To(BeNil())
+				}
 			} else {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(vm).To(BeNil())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:  It adds support for specifying the diskControllerType during the VM creation.

**Which issue(s) this PR fixes**:
#232 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
add support for specifying the diskControllerType during the VM creation.
```